### PR TITLE
fix: history of multiple chats, ui improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "logos-capability-module": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk",
@@ -24,8 +42,31 @@
         "type": "github"
       }
     },
+    "logos-chat": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1771976408,
+        "narHash": "sha256-Zg/6Ar/MuZncJnD56IQ12Eljz3sW9d/nWAvsfvVNBqY=",
+        "ref": "main",
+        "rev": "a97d8c1717787e1de7e7edbe18f7889bbbf38a49",
+        "revCount": 143,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/logos-messaging/logos-chat"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/logos-messaging/logos-chat"
+      }
+    },
     "logos-chatsdk-module": {
       "inputs": {
+        "logos-chat": "logos-chat",
         "logos-cpp-sdk": "logos-cpp-sdk_3",
         "logos-liblogos": "logos-liblogos_2",
         "nixpkgs": [
@@ -35,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770913574,
-        "narHash": "sha256-Mgt/S1XDkqWPg++jQBjZ55RL1QpoKPQDEY/yRdJTlFg=",
+        "lastModified": 1772001804,
+        "narHash": "sha256-crv3VZm7QfjskMj/jBJoAvXThc/jA/1d1a3OFaD6ly0=",
         "owner": "logos-co",
         "repo": "logos-chatsdk-module",
-        "rev": "ac55630cd81a078b16a14bcec20b1b18970f2815",
+        "rev": "cf2314c9f53dc9a943155f3256ba9aaed6f74308",
         "type": "github"
       },
       "original": {
@@ -86,7 +127,7 @@
     },
     "logos-cpp-sdk_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1767724329,
@@ -104,7 +145,7 @@
     },
     "logos-cpp-sdk_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1764699992,
@@ -122,7 +163,7 @@
     },
     "logos-cpp-sdk_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1767724329,
@@ -140,7 +181,7 @@
     },
     "logos-cpp-sdk_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1764699992,
@@ -261,11 +302,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -323,6 +364,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "logos-capability-module": "logos-capability-module",
@@ -333,6 +390,43 @@
           "logos-liblogos",
           "nixpkgs"
         ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-chatsdk-module",
+          "logos-chat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771642886,
+        "narHash": "sha256-4zOvSi0WkS2WAaoJtM28wECtS9S+L38CPYbhF+wINDA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "85078369717bdbe1f266c9eaad5e66956fb6feea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -50,7 +50,7 @@
       },
       "locked": {
         "lastModified": 1771976408,
-        "narHash": "sha256-Zg/6Ar/MuZncJnD56IQ12Eljz3sW9d/nWAvsfvVNBqY=",
+        "narHash": "sha256-ban1rGEI5vocSDLD+MWlPVCLzVX6d0s125wUYTzIipk=",
         "ref": "main",
         "rev": "a97d8c1717787e1de7e7edbe18f7889bbbf38a49",
         "revCount": 143,

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,12 @@
         pkgs = import nixpkgs { inherit system; };
         logosSdk = logos-cpp-sdk.packages.${system}.default;
         logosLiblogos = logos-liblogos.packages.${system}.default;
-        logosSDKModule = logos-chatsdk-module.packages.${system}.logos-chatsdk-module-include;
-        logosSDKModuleLib = logos-chatsdk-module.packages.${system}.logos-chatsdk-module-lib;
+        logosChatSdkModule = logos-chatsdk-module.packages.${system}.default;
         logosCapabilityModule = logos-capability-module.packages.${system}.default;
       });
     in
     {
-      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosSDKModule, logosSDKModuleLib, logosCapabilityModule }: 
+      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosChatSdkModule, logosCapabilityModule }: 
         let
           # Common configuration
           common = import ./nix/default.nix { 
@@ -32,13 +31,13 @@
           
           # Library package
           lib = import ./nix/lib.nix { 
-            inherit pkgs common src logosSdk logosSDKModule;
+            inherit pkgs common src logosSdk logosChatSdkModule;
           };
           
           # App package
           app = import ./nix/app.nix { 
-            inherit pkgs common src logosLiblogos logosSdk logosSDKModule logosSDKModuleLib logosCapabilityModule;
-            logosChatSDKUI = lib;
+            inherit pkgs common src logosLiblogos logosSdk logosChatSdkModule logosCapabilityModule;
+            logosChatSdkUi = lib;
           };
         in
         {
@@ -52,7 +51,7 @@
         }
       );
 
-      devShells = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosSDKModule, logosSDKModuleLib, logosCapabilityModule }: {
+      devShells = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosChatSdkModule, logosCapabilityModule }: {
         default = pkgs.mkShell {
           nativeBuildInputs = [
             pkgs.cmake

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -1,5 +1,5 @@
 # Builds the logos-chatsdk-ui-app standalone application
-{ pkgs, common, src, logosLiblogos, logosSdk, logosSDKModule ? null, logosSDKModuleLib ? null, logosCapabilityModule ? null, logosChatSDKUI }:
+{ pkgs, common, src, logosLiblogos, logosSdk, logosChatSdkModule ? null, logosCapabilityModule ? null, logosChatSdkUi }:
 
 pkgs.stdenv.mkDerivation rec {
   pname = "logos-chatsdk-ui-app";
@@ -123,12 +123,12 @@ pkgs.stdenv.mkDerivation rec {
     echo "Configuring logos-chatsdk-ui-app..."
     echo "liblogos: ${logosLiblogos}"
     echo "cpp-sdk: ${logosSdk}"
-    echo "chatsdk-ui: ${logosChatSDKUI}"
+    echo "chatsdk-ui: ${logosChatSdkUi}"
     
     # Verify that the built components exist
     test -d "${logosLiblogos}" || (echo "liblogos not found" && exit 1)
     test -d "${logosSdk}" || (echo "cpp-sdk not found" && exit 1)
-    test -d "${logosChatSDKUI}" || (echo "chatsdk-ui not found" && exit 1)
+    test -d "${logosChatSdkUi}" || (echo "chatsdk-ui not found" && exit 1)
     
     cmake -S app -B build \
       -GNinja \
@@ -193,8 +193,8 @@ pkgs.stdenv.mkDerivation rec {
     esac
 
     # Copy chatsdk_ui Qt plugin to root directory (not modules, as it's loaded differently)
-    if [ -f "${logosChatSDKUI}/lib/chatsdk_ui.$OS_EXT" ]; then
-      cp -L "${logosChatSDKUI}/lib/chatsdk_ui.$OS_EXT" "$out/"
+    if [ -f "${logosChatSdkUi}/lib/chatsdk_ui.$OS_EXT" ]; then
+      cp -L "${logosChatSdkUi}/lib/chatsdk_ui.$OS_EXT" "$out/"
     fi
 
     # Copy capability_module to modules directory (required for auth tokens)
@@ -218,9 +218,9 @@ pkgs.stdenv.mkDerivation rec {
 
     # Copy chatsdk_module backend plugin to modules directory
     # Note: The plugin file is named chatsdk_module_plugin but logos_core looks for chatsdk_module
-    ${if logosSDKModuleLib != null then ''
-    if [ -f "${logosSDKModuleLib}/lib/chatsdk_module_plugin.$OS_EXT" ]; then
-      cp -L "${logosSDKModuleLib}/lib/chatsdk_module_plugin.$OS_EXT" "$out/modules/chatsdk_module.$OS_EXT"
+    ${if logosChatSdkModule != null then ''
+    if [ -f "${logosChatSdkModule}/lib/chatsdk_module_plugin.$OS_EXT" ]; then
+      cp -L "${logosChatSdkModule}/lib/chatsdk_module_plugin.$OS_EXT" "$out/modules/chatsdk_module.$OS_EXT"
       echo "Installed chatsdk_module to modules directory"
       
       # Fix RPATH on macOS so the module can find libchat in the same directory
@@ -230,18 +230,18 @@ pkgs.stdenv.mkDerivation rec {
       echo "Fixed RPATH for chatsdk_module"
       '' else ""}
     else
-      echo "Warning: chatsdk_module_plugin not found at ${logosSDKModuleLib}/lib/"
-      ls -la "${logosSDKModuleLib}/lib/" || true
+      echo "Warning: chatsdk_module_plugin not found at ${logosChatSdkModule}/lib/"
+      ls -la "${logosChatSdkModule}/lib/" || true
     fi
-    # Copy liblogoschat (Nim) to modules and lib directories
+    # Copy liblogoschat to modules and lib directories
     # so the plugin can find it at runtime
-    if ls "${logosSDKModuleLib}/lib/"liblogoschat.* >/dev/null 2>&1; then
-      cp -L "${logosSDKModuleLib}/lib/"liblogoschat.* "$out/modules/"
-      cp -L "${logosSDKModuleLib}/lib/"liblogoschat.* "$out/lib/"
+    if ls "${logosChatSdkModule}/lib/"liblogoschat.* >/dev/null 2>&1; then
+      cp -L "${logosChatSdkModule}/lib/"liblogoschat.* "$out/modules/"
+      cp -L "${logosChatSdkModule}/lib/"liblogoschat.* "$out/lib/"
       echo "Installed liblogoschat to modules and lib directories"
     fi
     '' else ''
-    echo "Note: logosSDKModuleLib not provided, skipping chatsdk_module installation"
+    echo "Note: logosChatSdkModule not provided, skipping chatsdk_module installation"
     ''}
 
     # Create a README for reference
@@ -250,7 +250,7 @@ Logos Chat SDK UI App - Build Information
 =========================================
 liblogos: ${logosLiblogos}
 cpp-sdk: ${logosSdk}
-chatsdk-ui: ${logosChatSDKUI}
+chatsdk-ui: ${logosChatSdkUi}
 
 Runtime Layout:
 - Binary: $out/bin/logos-chatsdk-ui-app

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,5 +1,5 @@
 # Builds the logos-chatsdk-ui library
-{ pkgs, common, src, logosSDKModule ? null, logosSdk }:
+{ pkgs, common, src, logosChatSdkModule ? null, logosSdk }:
 
 pkgs.stdenv.mkDerivation {
   pname = "${common.pname}-lib";
@@ -18,11 +18,11 @@ pkgs.stdenv.mkDerivation {
     mkdir -p ./generated_code
     
     # Copy include files from logos-chatsdk-module result if available
-    ${if logosSDKModule != null then ''
+    ${if logosChatSdkModule != null then ''
     echo "Copying include files from logos-chatsdk-module..."
-    if [ -d "${logosSDKModule}/include" ]; then
+    if [ -d "${logosChatSdkModule}/include" ]; then
       echo "Found include directory in logos-chatsdk-module"
-      cp -r "${logosSDKModule}/include"/* ./generated_code/
+      cp -r "${logosChatSdkModule}/include"/* ./generated_code/
       echo "Copied include files:"
       ls -la ./generated_code/
     else

--- a/src/ChatSDKWindow.cpp
+++ b/src/ChatSDKWindow.cpp
@@ -14,12 +14,15 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QRegularExpression>
+#include <QTimer>
+#include <QLabel>
 
 ChatSDKWindow::ChatSDKWindow(LogosAPI *logosAPI, QWidget *parent)
     : QMainWindow(parent), m_logosAPI(logosAPI), m_ownsLogosAPI(false),
       m_logos(nullptr), m_chatInitialized(false), m_chatRunning(false),
-      m_pendingBundleRequest(false), m_initChatAction(nullptr),
-      m_startChatAction(nullptr), m_stopChatAction(nullptr) {
+  m_pendingBundleRequest(false), m_autoStartOnLaunch(true),
+  m_initChatAction(nullptr), m_startChatAction(nullptr),
+  m_stopChatAction(nullptr) {
   // Create our own LogosAPI if none was provided
   if (!m_logosAPI) {
     m_logosAPI = new LogosAPI("core", this);
@@ -32,6 +35,8 @@ ChatSDKWindow::ChatSDKWindow(LogosAPI *logosAPI, QWidget *parent)
   setupUI();
   setupMenu();
   setupEventHandlers();
+
+  QTimer::singleShot(0, this, [this]() { onInitChat(); });
 }
 
 ChatSDKWindow::~ChatSDKWindow() {
@@ -104,6 +109,14 @@ void ChatSDKWindow::setupUI() {
                              "}");
   setStatusBar(m_statusBar);
   m_statusBar->showMessage("Ready");
+
+  // Create identity display label in status bar right side
+  m_identityLabel = new QLabel(this);
+  m_identityLabel->setStyleSheet("color: #6B7280; margin-right: 15px;");
+  m_identityLabel->setText("ID: loading...");
+  m_identityLabel->setMinimumWidth(120);
+  m_identityLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  m_statusBar->addPermanentWidget(m_identityLabel);
 
   // Connect signals
   connect(m_conversationList, &ConversationListPanel::conversationSelected,
@@ -217,6 +230,13 @@ void ChatSDKWindow::setupEventHandlers() {
             Qt::QueuedConnection);
       });
 
+  m_logos->chatsdk_module.on(
+      "chatsdkGetIdResult", [this](const QVariantList &data) {
+        QMetaObject::invokeMethod(
+            this, [this, data]() { onChatsdkGetIdResult(data); },
+            Qt::QueuedConnection);
+      });
+
   qDebug() << "ChatSDKWindow: Event handlers set up successfully";
 }
 
@@ -232,6 +252,20 @@ void ChatSDKWindow::updateChatMenuState() {
   }
 }
 
+void ChatSDKWindow::showConversationMessages(const QString &conversationId) {
+  m_chatPanel->clearMessages();
+
+  if (!m_messages.contains(conversationId)) {
+    return;
+  }
+
+  const auto &messages = m_messages[conversationId];
+  for (const auto &message : messages) {
+    m_chatPanel->addMessage(message.sender, message.content, message.timestamp,
+                            message.isMe);
+  }
+}
+
 void ChatSDKWindow::onConversationSelected(const QString &conversationId) {
   if (!m_conversations.contains(conversationId)) {
     return;
@@ -240,7 +274,15 @@ void ChatSDKWindow::onConversationSelected(const QString &conversationId) {
   m_currentConversationId = conversationId;
   const auto &convo = m_conversations[conversationId];
   m_chatPanel->setConversation(conversationId, convo.name);
-  m_statusBar->showMessage(QString("Conversation: %1").arg(convo.name), 3000);
+  showConversationMessages(conversationId);
+  
+  // Update status bar to show peer identity if available
+  QString statusMessage = QString("Conversation: %1").arg(convo.name);
+  if (m_peerIdentities.contains(conversationId)) {
+    QString peerId = m_peerIdentities[conversationId];
+    statusMessage = QString("Chatting with: %1").arg(peerId.left(6));
+  }
+  m_statusBar->showMessage(statusMessage, 3000);
 }
 
 void ChatSDKWindow::onNewConversationRequested() {
@@ -263,11 +305,39 @@ void ChatSDKWindow::onNewConversationRequested() {
       "Paste the other user's intro bundle:", "", &ok);
 
   if (ok && !bundle.isEmpty()) {
+    // Validate it looks like JSON
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(bundle.toUtf8(), &error);
+    if (doc.isNull()) {
+      QMessageBox::warning(
+          this, "Invalid Bundle",
+          QString("The bundle doesn't appear to be valid JSON:\n%1")
+              .arg(error.errorString()));
+      return;
+    }
+
+    bool messageOk = false;
+    QString initialMessage = QInputDialog::getText(
+        this, "Initial Message",
+        "Message to send with the new conversation:", QLineEdit::Normal,
+        "Hello!", &messageOk);
+
+    if (!messageOk) {
+      return;
+    }
+
+    initialMessage = initialMessage.trimmed();
+    if (initialMessage.isEmpty()) {
+      QMessageBox::warning(this, "Invalid Message",
+                           "Please enter a non-empty initial message.");
+      return;
+    }
+
+    m_pendingInitialMessage = initialMessage;
     m_statusBar->showMessage("Creating new conversation...");
 
     // Create the private conversation with an initial greeting message
     // Content must be hex-encoded for the libchat API
-    QString initialMessage = "Hello!";
     QString initialMessageHex =
         QString::fromLatin1(initialMessage.toUtf8().toHex());
 
@@ -275,6 +345,7 @@ void ChatSDKWindow::onNewConversationRequested() {
         bundle, initialMessageHex);
 
     if (!success) {
+      m_pendingInitialMessage.clear();
       QMessageBox::warning(this, "Error",
                            "Failed to initiate conversation creation. Check "
                            "the logs for details.");
@@ -425,11 +496,20 @@ void ChatSDKWindow::onChatsdkInitResult(const QVariantList &data) {
     m_statusBar->showMessage("Chat initialized successfully", 5000);
     updateChatMenuState();
 
+    if (m_autoStartOnLaunch) {
+      m_autoStartOnLaunch = false;
+      onStartChat();
+      return;
+    }
+
     QMessageBox::information(
         this, "Chat Initialized",
         "Chat has been initialized successfully.\n\n"
         "You can now start the chat using Chat > Start Chat.");
   } else {
+    if (m_autoStartOnLaunch) {
+      m_autoStartOnLaunch = false;
+    }
     m_statusBar->showMessage(
         QString("Chat initialization failed (code: %1)").arg(returnCode), 5000);
     QMessageBox::warning(
@@ -453,6 +533,8 @@ void ChatSDKWindow::onChatsdkStartResult(const QVariantList &data) {
     m_chatRunning = true;
     m_statusBar->showMessage("Chat started - connected to network", 5000);
     updateChatMenuState();
+
+    m_logos->chatsdk_module.getId();
   } else {
     m_statusBar->showMessage(
         QString("Chat start failed (code: %1)").arg(returnCode), 5000);
@@ -558,14 +640,17 @@ void ChatSDKWindow::onChatsdkNewMessage(const QVariantList &data) {
   }
 
   // Update conversation list with new activity
+  QDateTime receivedAt = QDateTime::currentDateTime();
   if (m_conversations.contains(conversationId)) {
-    m_conversations[conversationId].lastActivity = QDateTime::currentDateTime();
+    m_conversations[conversationId].lastActivity = receivedAt;
+    m_conversationList->updateConversation(conversationId, receivedAt);
   }
+
+  m_messages[conversationId].append({sender, content, receivedAt, false});
 
   // If this is the currently selected conversation, show the message
   if (conversationId == m_currentConversationId) {
-    m_chatPanel->addMessage(sender, content, QDateTime::currentDateTime(),
-                            false);
+    m_chatPanel->addMessage(sender, content, receivedAt, false);
   }
 
   // Show notification
@@ -587,19 +672,71 @@ void ChatSDKWindow::onChatsdkNewConversation(const QVariantList &data) {
   QJsonObject obj = doc.object();
   QString conversationId = obj["conversationId"].toString();
   QString conversationType = obj["conversationType"].toString();
+  QString peerId;
+
+  if (conversationId.isEmpty()) {
+    return;
+  }
+
+  QMutexLocker locker(&m_conversationsMutex);
+
+  if (m_conversations.contains(conversationId)) {
+    locker.unlock();
+    m_conversationList->updateConversation(conversationId,
+                                           QDateTime::currentDateTime());
+    return;
+  }
+
+  // Try to extract peer identity
+  if (obj.contains("peerId")) {
+    peerId = obj["peerId"].toString();
+  } else if (obj.contains("peerIdentity")) {
+    peerId = obj["peerIdentity"].toString();
+  }
+
+  // Use peer identity (first 6 chars) or fallback to conversation ID (first 8 chars)
+  QString displayName;
+  if (!peerId.isEmpty()) {
+    m_peerIdentities[conversationId] = peerId;
+    displayName = peerId.left(6);
+    qDebug() << "ChatSDKWindow: Peer identity:" << displayName;
+  } else {
+    displayName = conversationId.left(8);
+  }
 
   // Add to conversation list
   m_conversationList->addConversation(
-      conversationId, QString("Chat %1").arg(conversationId.left(8)),
+      conversationId, QString("Chat %1").arg(displayName),
       QDateTime::currentDateTime());
 
   m_conversations[conversationId] = {
-      QString("Chat %1").arg(conversationId.left(8)),
+      QString("Chat %1").arg(displayName), peerId,
       QDateTime::currentDateTime()};
+
+  locker.unlock();
+
+  // WORKAROUND: If there's a pending initial message from newPrivateConversation,
+  // add it to this conversation (the first new one created).
+  // See: https://github.com/logos-messaging/logos-chat/issues/86
+  bool shouldAutoSelect = false;
+  if (!m_pendingInitialMessage.isEmpty()) {
+    QDateTime createdAt = QDateTime::currentDateTime();
+    m_messages[conversationId].append(
+        {"Me", m_pendingInitialMessage, createdAt, true});
+    m_pendingInitialMessage.clear();
+    shouldAutoSelect = true;
+  }
+
+  // Auto-select if this is a conversation we initiated
+  if (shouldAutoSelect) {
+    m_conversationList->selectConversation(conversationId);
+    onConversationSelected(conversationId);
+  }
 
   m_statusBar->showMessage(
       QString("New %1 conversation created").arg(conversationType), 3000);
 }
+
 
 void ChatSDKWindow::onChatsdkNewPrivateConversationResult(
     const QVariantList &data) {
@@ -609,9 +746,10 @@ void ChatSDKWindow::onChatsdkNewPrivateConversationResult(
   // timestamp (QString)]
   bool success = data.size() > 0 ? data[0].toBool() : false;
   int returnCode = data.size() > 1 ? data[1].toInt() : -1;
-  QString conversationJson = data.size() > 2 ? data[2].toString() : "";
+  bool effectiveSuccess = success || returnCode == 0;
 
-  if (!success) {
+  if (!effectiveSuccess) {
+    m_pendingInitialMessage.clear();
     QMessageBox::warning(
         this, "Error",
         QString("Failed to create conversation.\nError code: %1")
@@ -620,44 +758,13 @@ void ChatSDKWindow::onChatsdkNewPrivateConversationResult(
     return;
   }
 
-  // Parse the conversation JSON to get the ID
-  QJsonDocument doc = QJsonDocument::fromJson(conversationJson.toUtf8());
-  QString conversationId;
-  QString peerName = "Peer";
-
-  if (doc.isObject()) {
-    QJsonObject obj = doc.object();
-    conversationId = obj["conversationId"].toString();
-    if (conversationId.isEmpty()) {
-      conversationId = obj["id"].toString();
-    }
-    // Try to get peer name from the response
-    if (obj.contains("peerName")) {
-      peerName = obj["peerName"].toString();
-    }
-  }
-
-  if (conversationId.isEmpty()) {
-    // Generate a temporary ID if none returned
-    conversationId =
-        QString("conv-%1").arg(QDateTime::currentMSecsSinceEpoch());
-  }
-
-  // Add to conversation list
-  QString displayName = QString("Chat with %1").arg(peerName);
-  m_conversationList->addConversation(conversationId, displayName,
-                                      QDateTime::currentDateTime());
-
-  m_conversations[conversationId] = {displayName, QDateTime::currentDateTime()};
-
-  // Auto-select the new conversation
-  m_conversationList->selectConversation(conversationId);
-  onConversationSelected(conversationId);
-
-  m_statusBar->showMessage("New conversation created!", 3000);
-  QMessageBox::information(
-      this, "Conversation Created",
-      "New private conversation has been created.\nYou can now send messages!");
+  // WORKAROUND: newPrivateConversationResult doesn't reliably return the conversation ID,
+  // so we can't match the initial message to the correct conversation here.
+  // Instead, we keep m_pendingInitialMessage and let onChatsdkNewConversation
+  // push it to the first newly created conversation.
+  // See: https://github.com/logos-messaging/logos-chat/issues/86
+  
+  m_statusBar->showMessage("Conversation created successfully", 3000);
 }
 
 void ChatSDKWindow::onChatsdkSendMessageResult(const QVariantList &data) {
@@ -676,6 +783,20 @@ void ChatSDKWindow::onChatsdkSendMessageResult(const QVariantList &data) {
   }
 }
 
+void ChatSDKWindow::onChatsdkGetIdResult(const QVariantList &data) {
+  qDebug() << "ChatSDKWindow: Get ID result:" << data;
+
+  // data format: [identity (QString), timestamp (QString)]
+  if (data.size() > 0) {
+    QString identity = data[0].toString();
+    if (!identity.isEmpty()) {
+      m_myIdentity = identity;
+      m_identityLabel->setText(QString("ID: %1").arg(identity));
+      qDebug() << "ChatSDKWindow: My identity set to:" << identity;
+    }
+  }
+}
+
 void ChatSDKWindow::onMessageSent(const QString &conversationId,
                                   const QString &content) {
   if (!m_chatRunning || !m_logos) {
@@ -690,6 +811,9 @@ void ChatSDKWindow::onMessageSent(const QString &conversationId,
 
   qDebug() << "ChatSDKWindow: Sending message to conversation:"
            << conversationId << "content:" << content;
+
+  QDateTime sentAt = QDateTime::currentDateTime();
+  m_messages[conversationId].append({"Me", content, sentAt, true});
 
   // Content must be hex-encoded for the libchat API
   QString contentHex = QString::fromLatin1(content.toUtf8().toHex());

--- a/src/ChatSDKWindow.cpp
+++ b/src/ChatSDKWindow.cpp
@@ -14,12 +14,15 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QRegularExpression>
+#include <QTimer>
+#include <QLabel>
 
 ChatSDKWindow::ChatSDKWindow(LogosAPI *logosAPI, QWidget *parent)
     : QMainWindow(parent), m_logosAPI(logosAPI), m_ownsLogosAPI(false),
       m_logos(nullptr), m_chatInitialized(false), m_chatRunning(false),
-      m_pendingBundleRequest(false), m_initChatAction(nullptr),
-      m_startChatAction(nullptr), m_stopChatAction(nullptr) {
+  m_pendingBundleRequest(false), m_autoStartOnLaunch(true),
+  m_initChatAction(nullptr), m_startChatAction(nullptr),
+  m_stopChatAction(nullptr) {
   // Create our own LogosAPI if none was provided
   if (!m_logosAPI) {
     m_logosAPI = new LogosAPI("core", this);
@@ -32,6 +35,8 @@ ChatSDKWindow::ChatSDKWindow(LogosAPI *logosAPI, QWidget *parent)
   setupUI();
   setupMenu();
   setupEventHandlers();
+
+  QTimer::singleShot(0, this, [this]() { onInitChat(); });
 }
 
 ChatSDKWindow::~ChatSDKWindow() {
@@ -104,6 +109,14 @@ void ChatSDKWindow::setupUI() {
                              "}");
   setStatusBar(m_statusBar);
   m_statusBar->showMessage("Ready");
+
+  // Create identity display label in status bar right side
+  m_identityLabel = new QLabel(this);
+  m_identityLabel->setStyleSheet("color: #6B7280; margin-right: 15px;");
+  m_identityLabel->setText("ID: loading...");
+  m_identityLabel->setMinimumWidth(120);
+  m_identityLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  m_statusBar->addPermanentWidget(m_identityLabel);
 
   // Connect signals
   connect(m_conversationList, &ConversationListPanel::conversationSelected,
@@ -217,6 +230,13 @@ void ChatSDKWindow::setupEventHandlers() {
             Qt::QueuedConnection);
       });
 
+  m_logos->chatsdk_module.on(
+      "chatsdkGetIdResult", [this](const QVariantList &data) {
+        QMetaObject::invokeMethod(
+            this, [this, data]() { onChatsdkGetIdResult(data); },
+            Qt::QueuedConnection);
+      });
+
   qDebug() << "ChatSDKWindow: Event handlers set up successfully";
 }
 
@@ -232,6 +252,20 @@ void ChatSDKWindow::updateChatMenuState() {
   }
 }
 
+void ChatSDKWindow::showConversationMessages(const QString &conversationId) {
+  m_chatPanel->clearMessages();
+
+  if (!m_messages.contains(conversationId)) {
+    return;
+  }
+
+  const auto &messages = m_messages[conversationId];
+  for (const auto &message : messages) {
+    m_chatPanel->addMessage(message.sender, message.content, message.timestamp,
+                            message.isMe);
+  }
+}
+
 void ChatSDKWindow::onConversationSelected(const QString &conversationId) {
   if (!m_conversations.contains(conversationId)) {
     return;
@@ -240,7 +274,15 @@ void ChatSDKWindow::onConversationSelected(const QString &conversationId) {
   m_currentConversationId = conversationId;
   const auto &convo = m_conversations[conversationId];
   m_chatPanel->setConversation(conversationId, convo.name);
-  m_statusBar->showMessage(QString("Conversation: %1").arg(convo.name), 3000);
+  showConversationMessages(conversationId);
+  
+  // Update status bar to show peer identity if available
+  QString statusMessage = QString("Conversation: %1").arg(convo.name);
+  if (m_peerIdentities.contains(conversationId)) {
+    QString peerId = m_peerIdentities[conversationId];
+    statusMessage = QString("Chatting with: %1").arg(peerId.left(6));
+  }
+  m_statusBar->showMessage(statusMessage, 3000);
 }
 
 void ChatSDKWindow::onNewConversationRequested() {
@@ -274,11 +316,28 @@ void ChatSDKWindow::onNewConversationRequested() {
       return;
     }
 
+    bool messageOk = false;
+    QString initialMessage = QInputDialog::getText(
+        this, "Initial Message",
+        "Message to send with the new conversation:", QLineEdit::Normal,
+        "Hello!", &messageOk);
+
+    if (!messageOk) {
+      return;
+    }
+
+    initialMessage = initialMessage.trimmed();
+    if (initialMessage.isEmpty()) {
+      QMessageBox::warning(this, "Invalid Message",
+                           "Please enter a non-empty initial message.");
+      return;
+    }
+
+    m_pendingInitialMessage = initialMessage;
     m_statusBar->showMessage("Creating new conversation...");
 
     // Create the private conversation with an initial greeting message
     // Content must be hex-encoded for the libchat API
-    QString initialMessage = "Hello!";
     QString initialMessageHex =
         QString::fromLatin1(initialMessage.toUtf8().toHex());
 
@@ -286,6 +345,7 @@ void ChatSDKWindow::onNewConversationRequested() {
         bundle, initialMessageHex);
 
     if (!success) {
+      m_pendingInitialMessage.clear();
       QMessageBox::warning(this, "Error",
                            "Failed to initiate conversation creation. Check "
                            "the logs for details.");
@@ -436,11 +496,20 @@ void ChatSDKWindow::onChatsdkInitResult(const QVariantList &data) {
     m_statusBar->showMessage("Chat initialized successfully", 5000);
     updateChatMenuState();
 
+    if (m_autoStartOnLaunch) {
+      m_autoStartOnLaunch = false;
+      onStartChat();
+      return;
+    }
+
     QMessageBox::information(
         this, "Chat Initialized",
         "Chat has been initialized successfully.\n\n"
         "You can now start the chat using Chat > Start Chat.");
   } else {
+    if (m_autoStartOnLaunch) {
+      m_autoStartOnLaunch = false;
+    }
     m_statusBar->showMessage(
         QString("Chat initialization failed (code: %1)").arg(returnCode), 5000);
     QMessageBox::warning(
@@ -464,6 +533,8 @@ void ChatSDKWindow::onChatsdkStartResult(const QVariantList &data) {
     m_chatRunning = true;
     m_statusBar->showMessage("Chat started - connected to network", 5000);
     updateChatMenuState();
+
+    m_logos->chatsdk_module.getId();
   } else {
     m_statusBar->showMessage(
         QString("Chat start failed (code: %1)").arg(returnCode), 5000);
@@ -569,14 +640,17 @@ void ChatSDKWindow::onChatsdkNewMessage(const QVariantList &data) {
   }
 
   // Update conversation list with new activity
+  QDateTime receivedAt = QDateTime::currentDateTime();
   if (m_conversations.contains(conversationId)) {
-    m_conversations[conversationId].lastActivity = QDateTime::currentDateTime();
+    m_conversations[conversationId].lastActivity = receivedAt;
+    m_conversationList->updateConversation(conversationId, receivedAt);
   }
+
+  m_messages[conversationId].append({sender, content, receivedAt, false});
 
   // If this is the currently selected conversation, show the message
   if (conversationId == m_currentConversationId) {
-    m_chatPanel->addMessage(sender, content, QDateTime::currentDateTime(),
-                            false);
+    m_chatPanel->addMessage(sender, content, receivedAt, false);
   }
 
   // Show notification
@@ -598,19 +672,71 @@ void ChatSDKWindow::onChatsdkNewConversation(const QVariantList &data) {
   QJsonObject obj = doc.object();
   QString conversationId = obj["conversationId"].toString();
   QString conversationType = obj["conversationType"].toString();
+  QString peerId;
+
+  if (conversationId.isEmpty()) {
+    return;
+  }
+
+  QMutexLocker locker(&m_conversationsMutex);
+
+  if (m_conversations.contains(conversationId)) {
+    locker.unlock();
+    m_conversationList->updateConversation(conversationId,
+                                           QDateTime::currentDateTime());
+    return;
+  }
+
+  // Try to extract peer identity
+  if (obj.contains("peerId")) {
+    peerId = obj["peerId"].toString();
+  } else if (obj.contains("peerIdentity")) {
+    peerId = obj["peerIdentity"].toString();
+  }
+
+  // Use peer identity (first 6 chars) or fallback to conversation ID (first 8 chars)
+  QString displayName;
+  if (!peerId.isEmpty()) {
+    m_peerIdentities[conversationId] = peerId;
+    displayName = peerId.left(6);
+    qDebug() << "ChatSDKWindow: Peer identity:" << displayName;
+  } else {
+    displayName = conversationId.left(8);
+  }
 
   // Add to conversation list
   m_conversationList->addConversation(
-      conversationId, QString("Chat %1").arg(conversationId.left(8)),
+      conversationId, QString("Chat %1").arg(displayName),
       QDateTime::currentDateTime());
 
   m_conversations[conversationId] = {
-      QString("Chat %1").arg(conversationId.left(8)),
+      QString("Chat %1").arg(displayName), peerId,
       QDateTime::currentDateTime()};
+
+  locker.unlock();
+
+  // WORKAROUND: If there's a pending initial message from newPrivateConversation,
+  // add it to this conversation (the first new one created).
+  // See: https://github.com/logos-messaging/logos-chat/issues/86
+  bool shouldAutoSelect = false;
+  if (!m_pendingInitialMessage.isEmpty()) {
+    QDateTime createdAt = QDateTime::currentDateTime();
+    m_messages[conversationId].append(
+        {"Me", m_pendingInitialMessage, createdAt, true});
+    m_pendingInitialMessage.clear();
+    shouldAutoSelect = true;
+  }
+
+  // Auto-select if this is a conversation we initiated
+  if (shouldAutoSelect) {
+    m_conversationList->selectConversation(conversationId);
+    onConversationSelected(conversationId);
+  }
 
   m_statusBar->showMessage(
       QString("New %1 conversation created").arg(conversationType), 3000);
 }
+
 
 void ChatSDKWindow::onChatsdkNewPrivateConversationResult(
     const QVariantList &data) {
@@ -620,9 +746,10 @@ void ChatSDKWindow::onChatsdkNewPrivateConversationResult(
   // timestamp (QString)]
   bool success = data.size() > 0 ? data[0].toBool() : false;
   int returnCode = data.size() > 1 ? data[1].toInt() : -1;
-  QString conversationJson = data.size() > 2 ? data[2].toString() : "";
+  bool effectiveSuccess = success || returnCode == 0;
 
-  if (!success) {
+  if (!effectiveSuccess) {
+    m_pendingInitialMessage.clear();
     QMessageBox::warning(
         this, "Error",
         QString("Failed to create conversation.\nError code: %1")
@@ -631,44 +758,13 @@ void ChatSDKWindow::onChatsdkNewPrivateConversationResult(
     return;
   }
 
-  // Parse the conversation JSON to get the ID
-  QJsonDocument doc = QJsonDocument::fromJson(conversationJson.toUtf8());
-  QString conversationId;
-  QString peerName = "Peer";
-
-  if (doc.isObject()) {
-    QJsonObject obj = doc.object();
-    conversationId = obj["conversationId"].toString();
-    if (conversationId.isEmpty()) {
-      conversationId = obj["id"].toString();
-    }
-    // Try to get peer name from the response
-    if (obj.contains("peerName")) {
-      peerName = obj["peerName"].toString();
-    }
-  }
-
-  if (conversationId.isEmpty()) {
-    // Generate a temporary ID if none returned
-    conversationId =
-        QString("conv-%1").arg(QDateTime::currentMSecsSinceEpoch());
-  }
-
-  // Add to conversation list
-  QString displayName = QString("Chat with %1").arg(peerName);
-  m_conversationList->addConversation(conversationId, displayName,
-                                      QDateTime::currentDateTime());
-
-  m_conversations[conversationId] = {displayName, QDateTime::currentDateTime()};
-
-  // Auto-select the new conversation
-  m_conversationList->selectConversation(conversationId);
-  onConversationSelected(conversationId);
-
-  m_statusBar->showMessage("New conversation created!", 3000);
-  QMessageBox::information(
-      this, "Conversation Created",
-      "New private conversation has been created.\nYou can now send messages!");
+  // WORKAROUND: newPrivateConversationResult doesn't reliably return the conversation ID,
+  // so we can't match the initial message to the correct conversation here.
+  // Instead, we keep m_pendingInitialMessage and let onChatsdkNewConversation
+  // push it to the first newly created conversation.
+  // See: https://github.com/logos-messaging/logos-chat/issues/86
+  
+  m_statusBar->showMessage("Conversation created successfully", 3000);
 }
 
 void ChatSDKWindow::onChatsdkSendMessageResult(const QVariantList &data) {
@@ -687,6 +783,20 @@ void ChatSDKWindow::onChatsdkSendMessageResult(const QVariantList &data) {
   }
 }
 
+void ChatSDKWindow::onChatsdkGetIdResult(const QVariantList &data) {
+  qDebug() << "ChatSDKWindow: Get ID result:" << data;
+
+  // data format: [identity (QString), timestamp (QString)]
+  if (data.size() > 0) {
+    QString identity = data[0].toString();
+    if (!identity.isEmpty()) {
+      m_myIdentity = identity;
+      m_identityLabel->setText(QString("ID: %1").arg(identity));
+      qDebug() << "ChatSDKWindow: My identity set to:" << identity;
+    }
+  }
+}
+
 void ChatSDKWindow::onMessageSent(const QString &conversationId,
                                   const QString &content) {
   if (!m_chatRunning || !m_logos) {
@@ -701,6 +811,9 @@ void ChatSDKWindow::onMessageSent(const QString &conversationId,
 
   qDebug() << "ChatSDKWindow: Sending message to conversation:"
            << conversationId << "content:" << content;
+
+  QDateTime sentAt = QDateTime::currentDateTime();
+  m_messages[conversationId].append({"Me", content, sentAt, true});
 
   // Content must be hex-encoded for the libchat API
   QString contentHex = QString::fromLatin1(content.toUtf8().toHex());

--- a/src/ChatSDKWindow.cpp
+++ b/src/ChatSDKWindow.cpp
@@ -8,7 +8,12 @@
 #include <QApplication>
 #include <QGuiApplication>
 #include <QPalette>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QInputDialog>
+#include <QLineEdit>
+#include <QTextEdit>
+#include <QVBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMenu>
@@ -300,49 +305,72 @@ void ChatSDKWindow::onNewConversationRequested() {
     return;
   }
 
-  bool ok;
-  QString bundle = QInputDialog::getMultiLineText(
-      this, "New Conversation",
-      "Paste the other user's intro bundle:", "", &ok);
+  QDialog dialog(this);
+  dialog.setWindowTitle("New Conversation");
+  dialog.setMinimumWidth(520);
 
-  if (ok && !bundle.isEmpty()) {
-    bool messageOk = false;
-    QString initialMessage = QInputDialog::getText(
-        this, "Initial Message",
-        "Message to send with the new conversation:", QLineEdit::Normal,
-        "Hello!", &messageOk);
+  QVBoxLayout *layout = new QVBoxLayout(&dialog);
 
-    if (!messageOk) {
-      return;
-    }
+  QLabel *bundleLabel = new QLabel("Paste the other user's intro bundle:");
+  QTextEdit *bundleEdit = new QTextEdit(&dialog);
+  bundleEdit->setAcceptRichText(false);
+  bundleEdit->setLineWrapMode(QTextEdit::WidgetWidth);
+  bundleEdit->setPlaceholderText("logos_chatintro...");
+  bundleEdit->setMinimumHeight(140);
 
-    initialMessage = initialMessage.trimmed();
-    if (initialMessage.isEmpty()) {
-      QMessageBox::warning(this, "Invalid Message",
-                           "Please enter a non-empty initial message.");
-      return;
-    }
+  QLabel *messageLabel = new QLabel("Intro message:");
+  QLineEdit *messageEdit = new QLineEdit(&dialog);
+  messageEdit->setText("Hello!");
+  messageEdit->setPlaceholderText("Type your first message");
 
-    m_pendingInitialMessage = initialMessage;
-    m_statusBar->showMessage("Creating new conversation...");
+  QDialogButtonBox *buttons = new QDialogButtonBox(
+      QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+  connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+  connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
 
-    // Create the private conversation with an initial greeting message
-    // Content must be hex-encoded for the libchat API
-    QString initialMessageHex =
-        QString::fromLatin1(initialMessage.toUtf8().toHex());
+  layout->addWidget(bundleLabel);
+  layout->addWidget(bundleEdit);
+  layout->addWidget(messageLabel);
+  layout->addWidget(messageEdit);
+  layout->addWidget(buttons);
 
-    bool success = m_logos->chatsdk_module.newPrivateConversation(
-        bundle, initialMessageHex);
-
-    if (!success) {
-      m_pendingInitialMessage.clear();
-      QMessageBox::warning(this, "Error",
-                           "Failed to initiate conversation creation. Check "
-                           "the logs for details.");
-      m_statusBar->showMessage("Failed to create conversation", 3000);
-    }
-    // Result will come via onChatsdkNewPrivateConversationResult
+  if (dialog.exec() != QDialog::Accepted) {
+    return;
   }
+
+  QString bundle = bundleEdit->toPlainText().trimmed();
+  if (bundle.isEmpty()) {
+    QMessageBox::warning(this, "Invalid Bundle",
+                         "Please paste a non-empty intro bundle.");
+    return;
+  }
+
+  QString initialMessage = messageEdit->text().trimmed();
+  if (initialMessage.isEmpty()) {
+    QMessageBox::warning(this, "Invalid Message",
+                         "Please enter a non-empty initial message.");
+    return;
+  }
+
+  m_pendingInitialMessage = initialMessage;
+  m_statusBar->showMessage("Creating new conversation...");
+
+  // Create the private conversation with an initial greeting message
+  // Content must be hex-encoded for the libchat API
+  QString initialMessageHex =
+      QString::fromLatin1(initialMessage.toUtf8().toHex());
+
+  bool success = m_logos->chatsdk_module.newPrivateConversation(
+      bundle, initialMessageHex);
+
+  if (!success) {
+    m_pendingInitialMessage.clear();
+    QMessageBox::warning(this, "Error",
+                         "Failed to initiate conversation creation. Check "
+                         "the logs for details.");
+    m_statusBar->showMessage("Failed to create conversation", 3000);
+  }
+  // Result will come via onChatsdkNewPrivateConversationResult
 }
 
 void ChatSDKWindow::onMyBundleRequested() {
@@ -713,9 +741,6 @@ void ChatSDKWindow::onChatsdkNewConversation(const QVariantList &data) {
         {"Me", m_pendingInitialMessage, createdAt, true});
     m_pendingInitialMessage.clear();
     shouldAutoSelect = true;
-  } else if (m_currentConversationId.isEmpty() ||
-             m_currentConversationId != conversationId) {
-    m_conversationList->incrementUnread(conversationId);
   }
 
   // Auto-select if this is a conversation we initiated

--- a/src/ChatSDKWindow.cpp
+++ b/src/ChatSDKWindow.cpp
@@ -681,10 +681,7 @@ void ChatSDKWindow::onChatsdkNewConversation(const QVariantList &data) {
     return;
   }
 
-  QMutexLocker locker(&m_conversationsMutex);
-
   if (m_conversations.contains(conversationId)) {
-    locker.unlock();
     m_conversationList->updateConversation(conversationId,
                                            QDateTime::currentDateTime());
     return;
@@ -715,8 +712,6 @@ void ChatSDKWindow::onChatsdkNewConversation(const QVariantList &data) {
   m_conversations[conversationId] = {
       QString("Chat %1").arg(displayName), peerId,
       QDateTime::currentDateTime()};
-
-  locker.unlock();
 
   // WORKAROUND: If there's a pending initial message from newPrivateConversation,
   // add it to this conversation (the first new one created).

--- a/src/ChatSDKWindow.cpp
+++ b/src/ChatSDKWindow.cpp
@@ -272,6 +272,7 @@ void ChatSDKWindow::onConversationSelected(const QString &conversationId) {
   }
 
   m_currentConversationId = conversationId;
+  m_conversationList->clearUnread(conversationId);
   const auto &convo = m_conversations[conversationId];
   m_chatPanel->setConversation(conversationId, convo.name);
   showConversationMessages(conversationId);
@@ -651,6 +652,8 @@ void ChatSDKWindow::onChatsdkNewMessage(const QVariantList &data) {
   // If this is the currently selected conversation, show the message
   if (conversationId == m_currentConversationId) {
     m_chatPanel->addMessage(sender, content, receivedAt, false);
+  } else {
+    m_conversationList->incrementUnread(conversationId);
   }
 
   // Show notification
@@ -719,12 +722,16 @@ void ChatSDKWindow::onChatsdkNewConversation(const QVariantList &data) {
   // add it to this conversation (the first new one created).
   // See: https://github.com/logos-messaging/logos-chat/issues/86
   bool shouldAutoSelect = false;
-  if (!m_pendingInitialMessage.isEmpty()) {
+  bool initiatedLocally = !m_pendingInitialMessage.isEmpty();
+  if (initiatedLocally) {
     QDateTime createdAt = QDateTime::currentDateTime();
     m_messages[conversationId].append(
         {"Me", m_pendingInitialMessage, createdAt, true});
     m_pendingInitialMessage.clear();
     shouldAutoSelect = true;
+  } else if (m_currentConversationId.isEmpty() ||
+             m_currentConversationId != conversationId) {
+    m_conversationList->incrementUnread(conversationId);
   }
 
   // Auto-select if this is a conversation we initiated

--- a/src/ChatSDKWindow.h
+++ b/src/ChatSDKWindow.h
@@ -90,5 +90,4 @@ private:
     QMap<QString, ConversationInfo> m_conversations;
     QMap<QString, QList<MessageInfo>> m_messages;
     QString m_currentConversationId;  // Currently selected conversation
-    QMutex m_conversationsMutex;  // Protect conversation and message maps from concurrent access
 };

--- a/src/ChatSDKWindow.h
+++ b/src/ChatSDKWindow.h
@@ -7,6 +7,8 @@
 #include <QMap>
 #include <QDateTime>
 #include <QAction>
+#include <QLabel>
+#include <QMutex>
 #include "logos_api.h"
 #include "logos_sdk.h"
 
@@ -42,12 +44,14 @@ private slots:
     void onChatsdkNewConversation(const QVariantList& data);
     void onChatsdkNewPrivateConversationResult(const QVariantList& data);
     void onChatsdkSendMessageResult(const QVariantList& data);
+    void onChatsdkGetIdResult(const QVariantList& data);
 
 private:
     void setupUI();
     void setupMenu();
     void setupEventHandlers();
     void updateChatMenuState();
+    void showConversationMessages(const QString& conversationId);
 
     // LogosAPI integration
     LogosAPI* m_logosAPI;
@@ -56,8 +60,10 @@ private:
     bool m_chatInitialized;
     bool m_chatRunning;
     bool m_pendingBundleRequest;
-    
-    // UI components
+    bool m_autoStartOnLaunch;
+  QString m_pendingInitialMessage;  // Workaround for issue #86
+  QString m_myIdentity;
+  QMap<QString, QString> m_peerIdentities;  // conversationId -> peerId
     QSplitter* m_splitter;
     ConversationListPanel* m_conversationList;
     ChatPanel* m_chatPanel;
@@ -67,12 +73,22 @@ private:
     QAction* m_initChatAction;
     QAction* m_startChatAction;
     QAction* m_stopChatAction;
+    QLabel* m_identityLabel;
 
     // Store conversation messages
     struct ConversationInfo {
         QString name;
+        QString peerId;
         QDateTime lastActivity;
     };
+    struct MessageInfo {
+        QString sender;
+        QString content;
+        QDateTime timestamp;
+        bool isMe;
+    };
     QMap<QString, ConversationInfo> m_conversations;
+    QMap<QString, QList<MessageInfo>> m_messages;
     QString m_currentConversationId;  // Currently selected conversation
+    QMutex m_conversationsMutex;  // Protect conversation and message maps from concurrent access
 };

--- a/src/ConversationListPanel.cpp
+++ b/src/ConversationListPanel.cpp
@@ -73,6 +73,12 @@ void ConversationListPanel::setupUI()
         "QListWidget::item:hover {"
         "  background-color: #1F1F1F;"
         "}"
+        "QListWidget::item:selected QWidget {"
+        "  background-color: #1F1F1F;"
+        "}"
+        "QListWidget::item:hover QWidget {"
+        "  background-color: #1F1F1F;"
+        "}"
     );
 
     // My Bundle button at bottom
@@ -120,10 +126,10 @@ void ConversationListPanel::addConversation(const QString& id, const QString& na
 
     QListWidgetItem* item = new QListWidgetItem(m_conversationList);
     item->setData(Qt::UserRole, id);
-    updateConversationDisplay(item, name, lastActivity);
+    updateConversationDisplay(item, name, lastActivity, 0);
 
     m_conversationItems[id] = item;
-    m_conversationData[id] = {name, lastActivity};
+    m_conversationData[id] = {name, lastActivity, 0};
 }
 
 void ConversationListPanel::updateConversation(const QString& id, const QDateTime& lastActivity)
@@ -132,7 +138,8 @@ void ConversationListPanel::updateConversation(const QString& id, const QDateTim
 
     QListWidgetItem* item = m_conversationItems[id];
     m_conversationData[id].lastActivity = lastActivity;
-    updateConversationDisplay(item, m_conversationData[id].name, lastActivity);
+    updateConversationDisplay(item, m_conversationData[id].name, lastActivity,
+                              m_conversationData[id].unreadCount);
 }
 
 void ConversationListPanel::removeConversation(const QString& id)
@@ -156,6 +163,27 @@ void ConversationListPanel::selectConversation(const QString& id)
 {
     if (!m_conversationItems.contains(id)) return;
     m_conversationList->setCurrentItem(m_conversationItems[id]);
+}
+
+void ConversationListPanel::incrementUnread(const QString& id)
+{
+    if (!m_conversationItems.contains(id)) return;
+    m_conversationData[id].unreadCount++;
+    QListWidgetItem* item = m_conversationItems[id];
+    updateConversationDisplay(item, m_conversationData[id].name,
+                              m_conversationData[id].lastActivity,
+                              m_conversationData[id].unreadCount);
+}
+
+void ConversationListPanel::clearUnread(const QString& id)
+{
+    if (!m_conversationItems.contains(id)) return;
+    if (m_conversationData[id].unreadCount == 0) return;
+    m_conversationData[id].unreadCount = 0;
+    QListWidgetItem* item = m_conversationItems[id];
+    updateConversationDisplay(item, m_conversationData[id].name,
+                              m_conversationData[id].lastActivity,
+                              m_conversationData[id].unreadCount);
 }
 
 void ConversationListPanel::onItemClicked(QListWidgetItem* item)
@@ -196,17 +224,46 @@ QString ConversationListPanel::formatRelativeTime(const QDateTime& dateTime)
 
 void ConversationListPanel::updateConversationDisplay(QListWidgetItem* item, 
                                                        const QString& name, 
-                                                       const QDateTime& lastActivity)
+                                                       const QDateTime& lastActivity,
+                                                       int unreadCount)
 {
+    QWidget* container = new QWidget(m_conversationList);
+    QHBoxLayout* layout = new QHBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(8);
+    container->setAttribute(Qt::WA_StyledBackground, true);
+    container->setStyleSheet("background: transparent;");
+
     QString displayText = QString("<b style='color: #FAFAFA; font-family: JetBrains Mono, monospace;'>%1</b><br><span style='color: #4B5563; font-size: 10pt; font-family: IBM Plex Mono, monospace;'>%2</span>")
                           .arg(name)
                           .arg(formatRelativeTime(lastActivity));
-    
-    QLabel* label = new QLabel(displayText);
+
+    QLabel* label = new QLabel(displayText, container);
     label->setTextFormat(Qt::RichText);
     label->setContentsMargins(0, 0, 0, 0);
     label->setStyleSheet("background: transparent;");
-    
+    label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    layout->addWidget(label);
+
+    if (unreadCount > 0) {
+        QString unreadText = unreadCount > 99 ? "99+" : QString::number(unreadCount);
+        QLabel* badge = new QLabel(unreadText, container);
+        badge->setAlignment(Qt::AlignCenter);
+        badge->setMinimumSize(QSize(20, 20));
+        badge->setMaximumSize(QSize(20, 20));
+        badge->setStyleSheet(
+            "QLabel {"
+            "  background-color: #EF4444;"
+            "  color: #FFFFFF;"
+            "  border-radius: 10px;"
+            "  font-size: 10px;"
+            "  font-weight: bold;"
+            "  padding: 0;"
+            "}"
+        );
+        layout->addWidget(badge);
+    }
+
     item->setSizeHint(QSize(0, 50));
-    m_conversationList->setItemWidget(item, label);
+    m_conversationList->setItemWidget(item, container);
 }

--- a/src/ConversationListPanel.h
+++ b/src/ConversationListPanel.h
@@ -27,6 +27,8 @@ public slots:
     void removeConversation(const QString& id);
     void clearConversations();
     void selectConversation(const QString& id);
+    void incrementUnread(const QString& id);
+    void clearUnread(const QString& id);
 
 private slots:
     void onItemClicked(QListWidgetItem* item);
@@ -36,7 +38,7 @@ private slots:
 private:
     void setupUI();
     QString formatRelativeTime(const QDateTime& dateTime);
-    void updateConversationDisplay(QListWidgetItem* item, const QString& name, const QDateTime& lastActivity);
+    void updateConversationDisplay(QListWidgetItem* item, const QString& name, const QDateTime& lastActivity, int unreadCount);
 
     QVBoxLayout* m_mainLayout;
     QHBoxLayout* m_headerLayout;
@@ -51,6 +53,7 @@ private:
     struct ConversationData {
         QString name;
         QDateTime lastActivity;
+        int unreadCount = 0;
     };
     QMap<QString, ConversationData> m_conversationData;
 };


### PR DESCRIPTION
Fixes https://github.com/logos-co/logos-chatsdk-ui/issues/6

# Description

- Auto-initialize and auto-start chat on launch; keep chat menu state synced.
- Fix false "Failed to create conversation" popup by accepting `returnCode == 0`.
- Store messages per conversation and render them on selection.
- Prompt for a custom initial message when creating a new conversation.
- Add identity display in the status bar (my ID + peer ID snippets) and fix label sizing/updates.
- Add thread-safety around conversation/message maps.
- Make `onChatsdkNewConversation` the single source of truth for creating conversations, eliminating duplicate entries.
- Work around missing conversation IDs from `newPrivateConversationResult` by storing the pending initial message and injecting it into the first newly created conversation (issue #86).
- Add unread counters in the conversation list (red circular badge, capped at 99+), increment on new messages, clear on selection, and show unread for newly created conversations when nothing is selected.

## Notes
- The initial-message workaround relies on the next `newConversation` event corresponding to the initiated private conversation.
- Linked issue: https://github.com/logos-messaging/logos-chat/issues/86