### PR TITLE
fix: parse new chat_module JSON bundle event (Get Intro Bundle is broken)

### DIFF
--- a/src/ChatBackend.cpp
+++ b/src/ChatBackend.cpp
@@ -335,8 +335,21 @@ void ChatBackend::onChatCreateIntroBundleResult(const QVariantList& data)
     if (!m_pendingBundleRequest) return;
     m_pendingBundleRequest = false;
 
-    bool success = data.size() > 0 ? data[0].toBool() : false;
-    QString bundleStr = data.size() > 2 ? data[2].toString() : QString();
+    // Newer chat_module emits a single JSON string {"success":bool,"introBundle":str,...};
+    // older builds emitted a [bool, int, str, ...] array. Handle both.
+    bool success = false;
+    QString bundleStr;
+    if (!data.isEmpty()) {
+        const QJsonDocument doc = QJsonDocument::fromJson(data[0].toString().toUtf8());
+        if (doc.isObject()) {
+            const QJsonObject o = doc.object();
+            success   = o.value("success").toBool();
+            bundleStr = o.value("introBundle").toString();
+        } else if (data.size() > 2) {                 // legacy array format
+            success   = data[0].toBool();
+            bundleStr = data[2].toString();
+        }
+    }
 
     if (success && !bundleStr.isEmpty()) {
         setStatusMessage(QStringLiteral("Bundle ready"));


### PR DESCRIPTION
## Problem

`ChatBackend::onChatCreateIntroBundleResult` reads the bundle event as a legacy
`[bool, int, string, …]` array (`data[0].toBool()`, `data[2].toString()`). But the current
`chat_module` (logos-chat-module, latest) emits the event as a **single JSON string**:

```cpp
deferredEmit(impl, "chatCreateIntroBundleResult", ev.dump());   // {"success":…,"introBundle":…,…}
```

So `success` parses as `false` and **every "Get Intro Bundle" fails** with "Failed to create
intro bundle" — even though the module created the bundle successfully (verified: chat_module
logs `IntroBundleCreated`, ret 0).

## Fix

Parse `data[0]` as JSON (`{"success", "introBundle"}`), falling back to the legacy array
format for older `chat_module` builds. One-file change in `ChatBackend.cpp`.

Independent of any feature — this unblocks the intro-bundle flow against the current chat_module.
