### PR TITLE
chore(deps): bump chat_module and delivery module pins

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1782393691,
-        "narHash": "sha256-/4E0pwc2JlHPKBeQlKGiZPXdH0sN17V/NQiDl/gEXAs=",
+        "lastModified": 1782991566,
+        "narHash": "sha256-LTV0hUweHABY3TycE8kIYiS5rehJoih7r1S3ZuUZut4=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "a58b5ffe71e458be72aaf51a4775a2e9239255cf",
+        "rev": "4fe912ad5bacc286fb31f674bea6092730945a7c",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "a58b5ffe71e458be72aaf51a4775a2e9239255cf",
+        "rev": "4fe912ad5bacc286fb31f674bea6092730945a7c",
         "type": "github"
       }
     },
@@ -2180,17 +2180,17 @@
         "nix-bundle-lgx": "nix-bundle-lgx_10"
       },
       "locked": {
-        "lastModified": 1781019490,
-        "narHash": "sha256-TQXLZMbK4pW9vfaq6RNNUYzm0gX4DjxhtywavFyo5Wc=",
+        "lastModified": 1782251051,
+        "narHash": "sha256-ggpO1f8ANSE2swemWtmbQeSpj7Nuq2Y51+GnlhsR25s=",
         "owner": "logos-co",
         "repo": "logos-delivery-module",
-        "rev": "2577383f6e0de24793b523d6ea4991aa6339afd8",
+        "rev": "794c21cbe177bdea16d4907468eaf52d4282dda7",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "v0.1.3",
         "repo": "logos-delivery-module",
-        "rev": "2577383f6e0de24793b523d6ea4991aa6339afd8",
         "type": "github"
       }
     },
@@ -2201,17 +2201,17 @@
         "nix-bundle-lgx": "nix-bundle-lgx_29"
       },
       "locked": {
-        "lastModified": 1781019490,
-        "narHash": "sha256-TQXLZMbK4pW9vfaq6RNNUYzm0gX4DjxhtywavFyo5Wc=",
+        "lastModified": 1782251051,
+        "narHash": "sha256-ggpO1f8ANSE2swemWtmbQeSpj7Nuq2Y51+GnlhsR25s=",
         "owner": "logos-co",
         "repo": "logos-delivery-module",
-        "rev": "2577383f6e0de24793b523d6ea4991aa6339afd8",
+        "rev": "794c21cbe177bdea16d4907468eaf52d4282dda7",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "v0.1.3",
         "repo": "logos-delivery-module",
-        "rev": "2577383f6e0de24793b523d6ea4991aa6339afd8",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1782991566,
-        "narHash": "sha256-LTV0hUweHABY3TycE8kIYiS5rehJoih7r1S3ZuUZut4=",
+        "lastModified": 1782994912,
+        "narHash": "sha256-s4YnMM5KAFdBm6K66H6VHQlx+ujwba3uhruFC5jqLyg=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "4fe912ad5bacc286fb31f674bea6092730945a7c",
+        "rev": "53ffe3b999f7e66bb693e38db00f4e86632b2798",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "v0.1.2",
         "repo": "logos-chat-module",
-        "rev": "4fe912ad5bacc286fb31f674bea6092730945a7c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,16 +6,15 @@
     # logos-protocol/logos-qt-sdk chain matches across both.
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    # Pinned to an explicit master rev (like logos-delivery-module below) instead
-    # of a moving branch ref, so the chat_module contract can't shift under a
-    # `nix flake update`. Re-pin to the new rev whenever chat_module advances;
-    # switch to a release tag once one is cut.
-    chat_module.url = "github:logos-co/logos-chat-module/a58b5ffe71e458be72aaf51a4775a2e9239255cf";
-    # Pinned to the commit (post-v0.1.2) carrying the zerokit/RLN nix build fix:
-    # delivery-module #49 bumps logos-delivery so zerokit's cargo vendor no longer
-    # hits crates.io's python-requests 403. Not yet tagged — re-pin to the release
-    # tag once one is cut.
-    logos-delivery-module.url = "github:logos-co/logos-delivery-module/2577383f6e0de24793b523d6ea4991aa6339afd8";
+    # Pinned to an explicit master rev instead of a moving branch ref, so the
+    # chat_module contract can't shift under a `nix flake update`. This rev is
+    # the v0.1.2 release candidate (delivery pinned to v0.1.3, chat-module #41);
+    # re-pin to the v0.1.2 tag once that release is published.
+    chat_module.url = "github:logos-co/logos-chat-module/4fe912ad5bacc286fb31f674bea6092730945a7c";
+    # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix build
+    # fix (delivery-module #49: zerokit's cargo vendor no longer hits crates.io's
+    # python-requests 403). Kept in lockstep with chat_module's pin above.
+    logos-delivery-module.url = "github:logos-co/logos-delivery-module/v0.1.3";
   };
 
   outputs = inputs@{ logos-module-builder, logos-delivery-module, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,9 @@
     # logos-protocol/logos-qt-sdk chain matches across both.
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    # Pinned to an explicit master rev instead of a moving branch ref, so the
-    # chat_module contract can't shift under a `nix flake update`. This rev is
-    # the v0.1.2 release candidate (delivery pinned to v0.1.3, chat-module #41);
-    # re-pin to the v0.1.2 tag once that release is published.
-    chat_module.url = "github:logos-co/logos-chat-module/4fe912ad5bacc286fb31f674bea6092730945a7c";
+    # Pinned to the v0.1.2 release tag (delivery pinned to v0.1.3), so the
+    # chat_module contract can't shift under a `nix flake update`.
+    chat_module.url = "github:logos-co/logos-chat-module/v0.1.2";
     # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix build
     # fix (delivery-module #49: zerokit's cargo vendor no longer hits crates.io's
     # python-requests 403). Kept in lockstep with chat_module's pin above.

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "chat_ui",
   "display_name": "Chat",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "ui_qml",
   "interface": "universal",
   "category": "chat",


### PR DESCRIPTION
Bumps both module pins in `flake.nix` to their release tags, regenerates `flake.lock`, and bumps the module's own version ahead of the chat_ui v0.1.2 release:

- **`chat_module`**: `a58b5ff` → the `v0.1.2` release tag (locks to `53ffe3b`; includes the delivery v0.1.3 pin from logos-co/logos-chat-module#41 and the metadata version bump from logos-co/logos-chat-module#42).
- **`logos-delivery-module`**: raw commit `2577383` → the `v0.1.3` release tag, which carries the zerokit/RLN nix build fix (logos-co/logos-delivery-module#49) the old stopgap pin was for.
- **`metadata.json`**: `version` 0.1.1 → 0.1.2 for the release that follows this merge.

Both delivery pins (top-level and nested under `chat_module`) lock to the same rev (`794c21c`), keeping the lockstep the flake comments call for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)