### PR TITLE
feat: create groups with a name and description

### DIFF
--- a/doctests/group/run-group.mjs
+++ b/doctests/group/run-group.mjs
@@ -128,6 +128,11 @@ async function getAddress(insp) {
 }
 
 const CONV_ID_ROLE = 257; // ConversationListModel::ConversationIdRole (Qt::UserRole + 1)
+const DISPLAY_NAME_ROLE = 258; // ConversationListModel::DisplayNameRole
+// The group's shared name and description, set by the creator and carried to
+// every joiner. The joiners' display name resolves to GROUP_NAME (nickname unset).
+const GROUP_NAME = "Book Club";
+const GROUP_DESC = "Weekly sci-fi picks";
 // Must match doctests/chat-ui-group.test.yaml's wait_for text exactly:
 // findByProperty matches the whole `text` property, not a substring.
 const GROUP_MSG = "Hello team \u{1F44B}";
@@ -158,7 +163,7 @@ async function main() {
   console.log(`bob address: ${bobAddr.length} chars, carol address: ${carolAddr.length} chars`);
 
   console.log("alice: create the group...");
-  await evalq(alice, "store.backend.createGroupConversation()");
+  await evalq(alice, `store.backend.createGroupConversation(${JSON.stringify(GROUP_NAME)}, ${JSON.stringify(GROUP_DESC)})`);
   await waitFor(async () => (await evalq(alice, "store.backend.currentConversationId")) !== "", { timeout: 30000, what: "group created" });
   const groupId = await evalq(alice, "store.backend.currentConversationId");
   console.log(`group id: ${groupId}`);
@@ -192,6 +197,11 @@ async function main() {
   // her roster.
   console.log("carol: open the group and wait for alice's message...");
   const carolGroup = await evalq(carol, `store.conversationModel.data(store.conversationModel.index(0,0), ${CONV_ID_ROLE})`);
+  // The shared name reached the joiner end to end: carol set no local nickname,
+  // so her display name resolves to the group name Alice created it with.
+  const carolName = await evalq(carol, `store.conversationModel.data(store.conversationModel.index(0,0), ${DISPLAY_NAME_ROLE})`);
+  if (carolName !== GROUP_NAME) throw new Error(`carol should see the shared group name ${JSON.stringify(GROUP_NAME)}, got ${JSON.stringify(carolName)}`);
+  console.log(`carol sees the group name: ${JSON.stringify(carolName)}`);
   await loadThread(carol, carolGroup, 1, { timeout: 300000 });
   await waitForRoster(carol, 3, { what: "carol's roster" });
   console.log("carol: received the group message");

--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1784188525,
-        "narHash": "sha256-sVTjOkloEla7hDKEQ3b1MAJQ92W/l4uXyQoq3xjYGsE=",
+        "lastModified": 1784235127,
+        "narHash": "sha256-thnxGQRA37NfZJBEuWsuoyzX482YTpgtwJXQM7+aZZE=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "2354fecb26183714ecd0aa174cf57ee1d544125f",
+        "rev": "4b5b5d955971ba1c9c49495f2be11ed1f29d136a",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "2354fecb26183714ecd0aa174cf57ee1d544125f",
+        "rev": "4b5b5d955971ba1c9c49495f2be11ed1f29d136a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,12 @@
     # logos-protocol/logos-qt-sdk chain matches across both.
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    # Pinned to the chat_module master commit that surfaces the members_changed
-    # event; re-pin whenever chat_module advances, and switch to a release tag
-    # once one is cut. Delivery stays on the v0.1.3 tag below, matching
-    # chat_module's own delivery pin.
-    chat_module.url = "github:logos-co/logos-chat-module/2354fecb26183714ecd0aa174cf57ee1d544125f";
+    # Pinned to the chat_module commit that adds a group name and description to
+    # create_group_conversation and surfaces them on the Conversation record and
+    # conversation_created event; re-pin whenever chat_module advances, and switch
+    # to a release tag once one is cut. Delivery stays on the v0.1.3 tag below,
+    # matching chat_module's own delivery pin.
+    chat_module.url = "github:logos-co/logos-chat-module/4b5b5d955971ba1c9c49495f2be11ed1f29d136a";
     # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix build
     # fix (delivery-module #49: zerokit's cargo vendor no longer hits crates.io's
     # python-requests 403). Kept in lockstep with chat_module's delivery pin.

--- a/src/ChatBackend.cpp
+++ b/src/ChatBackend.cpp
@@ -198,12 +198,15 @@ void ChatBackend::rehydrateConversations()
         const QString convoId = obj.value(QStringLiteral("convo_id")).toString();
         if (convoId.isEmpty()) continue;
         const QString nickname = obj.value(QStringLiteral("nickname")).toString();
+        const QString name = obj.value(QStringLiteral("name")).toString();
+        const QString description = obj.value(QStringLiteral("description")).toString();
         const qint64 lastActivity = obj.value(QStringLiteral("last_activity_ms")).toLongLong();
         const bool isGroup = obj.value(QStringLiteral("kind")).toString() == QStringLiteral("group");
-        m_conversationModel->addConversation(convoId,
-                                             nickname.isEmpty()
-                                                 ? fallbackDisplayName(convoId, QString(), isGroup)
-                                                 : nickname,
+        // Local nickname wins, then the group's shared name, else a generated label.
+        const QString displayName = !nickname.isEmpty() ? nickname
+            : !name.isEmpty()                           ? name
+                                                        : fallbackDisplayName(convoId, QString(), isGroup);
+        m_conversationModel->addConversation(convoId, displayName, description,
                                              msToDateTime(lastActivity), isGroup);
     }
     // The rebuilt list may now know the current conversation's kind/name.
@@ -219,6 +222,7 @@ void ChatBackend::syncCurrentConversationMeta()
     const QString id = currentConversationId();
     setCurrentIsGroup(m_conversationModel->isGroupFor(id));
     setCurrentDisplayName(m_conversationModel->displayNameFor(id));
+    setCurrentDescription(m_conversationModel->descriptionFor(id));
 }
 
 void ChatBackend::showConversationMessages(const QString& convoId)
@@ -272,7 +276,7 @@ void ChatBackend::createConversation(QString peerAddress)
     // appliers handle the UI side from there.
 }
 
-void ChatBackend::createGroupConversation()
+void ChatBackend::createGroupConversation(QString name, QString description)
 {
     if (chatStatus() != ChatBackendSimpleSource::Online || !isContextReady()) {
         emit error(QStringLiteral("Chat not online"));
@@ -280,7 +284,7 @@ void ChatBackend::createGroupConversation()
     }
 
     setStatusMessage(QStringLiteral("Creating group..."));
-    const LogosResult res = modules().chat_module.create_group_conversation();
+    const LogosResult res = modules().chat_module.create_group_conversation(name, description);
     if (!res.success) {
         const QString reason = res.getError<QString>();
         setStatusMessage(QStringLiteral("Failed to create group: ") + reason);
@@ -465,7 +469,7 @@ void ChatBackend::applyMessageReceived(const QVariantList& args)
         // Defensive: ConversationStarted normally lands first with the kind.
         // Add it now and backfill the kind by re-reading the list (deferred:
         // this runs inside a module event callback, see deferToEventLoop).
-        m_conversationModel->addConversation(convoId, fallbackDisplayName(convoId), when, false);
+        m_conversationModel->addConversation(convoId, fallbackDisplayName(convoId), QString(), when, false);
         deferToEventLoop([this] { rehydrateConversations(); });
     } else {
         m_conversationModel->updateLastActivity(convoId, when);
@@ -493,7 +497,7 @@ void ChatBackend::applyMessageSent(const QVariantList& args)
     const QDateTime when = msToDateTime(ts);
 
     if (!m_conversationModel->contains(convoId)) {
-        m_conversationModel->addConversation(convoId, fallbackDisplayName(convoId), when, false);
+        m_conversationModel->addConversation(convoId, fallbackDisplayName(convoId), QString(), when, false);
     } else {
         m_conversationModel->updateLastActivity(convoId, when);
     }
@@ -511,13 +515,17 @@ void ChatBackend::applyConversationCreated(const QVariantList& args)
     const bool isOutgoing = args.value(1).toBool();
     const QString peerLabel = args.value(2).toString();
     const bool isGroup = args.value(3).toString() == QStringLiteral("group");
-    const QString displayName = fallbackDisplayName(convoId, peerLabel, isGroup);
+    const QString name = args.value(4).toString();
+    const QString description = args.value(5).toString();
+    const QString displayName =
+        name.isEmpty() ? fallbackDisplayName(convoId, peerLabel, isGroup) : name;
     const QDateTime now = QDateTime::currentDateTime();
 
     if (!m_conversationModel->contains(convoId)) {
-        m_conversationModel->addConversation(convoId, displayName, now, isGroup);
+        m_conversationModel->addConversation(convoId, displayName, description, now, isGroup);
     } else {
         m_conversationModel->updateDisplayName(convoId, displayName);
+        m_conversationModel->updateDescription(convoId, description);
         m_conversationModel->updateLastActivity(convoId, now);
     }
 

--- a/src/ChatBackend.h
+++ b/src/ChatBackend.h
@@ -34,7 +34,7 @@ public:
 
 public slots:
     void createConversation(QString peerAddress) override;
-    void createGroupConversation() override;
+    void createGroupConversation(QString name, QString description) override;
     void addGroupMember(QString conversationId, QString peerAddress) override;
     void requestMyAddress() override;
     void sendMessage(QString conversationId, QString content) override;
@@ -56,9 +56,9 @@ private:
     void initialiseModule();
     void subscribeToEvents();
     void rehydrateConversations();
-    // Pushes the current conversation's group flag and display name as backend
-    // properties for the QML view to bind — see the .cpp for why the view can't
-    // read them off the model directly.
+    // Pushes the current conversation's group flag, display name, and description
+    // as backend properties for the QML view to bind — see the .cpp for why the
+    // view can't read them off the model directly.
     void syncCurrentConversationMeta();
     void showConversationMessages(const QString& convoId);
 

--- a/src/ChatBackend.rep
+++ b/src/ChatBackend.rep
@@ -13,16 +13,17 @@ class ChatBackend
     PROP(QString currentConversationId)
     // Derived from the current conversation, kept here (not read off the model)
     // because the models reach QML as QtRO replicas that don't proxy the model's
-    // Q_INVOKABLE lookups (isGroupFor/displayNameFor).
+    // Q_INVOKABLE lookups (isGroupFor/displayNameFor/descriptionFor).
     PROP(bool currentIsGroup READONLY)
     PROP(QString currentDisplayName READONLY)
+    PROP(QString currentDescription READONLY)
     // The current group's roster size. Exposed as a property (not read off
     // memberModel) because the model reaches QML as a QtRO replica whose
     // rowCount() a non-view caller can't rely on.
     PROP(int memberCount READONLY)
 
     SLOT(void createConversation(QString peerAddress))
-    SLOT(void createGroupConversation())
+    SLOT(void createGroupConversation(QString name, QString description))
     SLOT(void addGroupMember(QString conversationId, QString peerAddress))
     SLOT(void requestMyAddress())
     SLOT(void sendMessage(QString conversationId, QString content))

--- a/src/ConversationListModel.cpp
+++ b/src/ConversationListModel.cpp
@@ -39,12 +39,13 @@ QHash<int, QByteArray> ConversationListModel::roleNames() const
 }
 
 void ConversationListModel::addConversation(const QString& id, const QString& displayName,
-                                            const QDateTime& lastActivity, bool isGroup)
+                                            const QString& description, const QDateTime& lastActivity,
+                                            bool isGroup)
 {
     if (contains(id)) return;
 
     beginInsertRows(QModelIndex(), m_items.size(), m_items.size());
-    m_items.append({ id, displayName, lastActivity, 0, isGroup });
+    m_items.append({ id, displayName, description, lastActivity, 0, isGroup });
     endInsertRows();
 }
 
@@ -56,6 +57,13 @@ void ConversationListModel::updateDisplayName(const QString& id, const QString& 
     if (m_items[idx].displayName == displayName) return;
     m_items[idx].displayName = displayName;
     emit dataChanged(index(idx), index(idx), { DisplayNameRole });
+}
+
+void ConversationListModel::updateDescription(const QString& id, const QString& description)
+{
+    int idx = indexOf(id);
+    if (idx < 0) return;
+    m_items[idx].description = description;
 }
 
 void ConversationListModel::updateLastActivity(const QString& id, const QDateTime& lastActivity)
@@ -122,6 +130,12 @@ QString ConversationListModel::displayNameFor(const QString& id) const
 {
     const int idx = indexOf(id);
     return idx < 0 ? QString() : m_items.at(idx).displayName;
+}
+
+QString ConversationListModel::descriptionFor(const QString& id) const
+{
+    const int idx = indexOf(id);
+    return idx < 0 ? QString() : m_items.at(idx).description;
 }
 
 bool ConversationListModel::isGroupFor(const QString& id) const

--- a/src/ConversationListModel.h
+++ b/src/ConversationListModel.h
@@ -9,6 +9,7 @@
 struct ConversationItem {
     QString conversationId;
     QString displayName;
+    QString description;
     QDateTime lastActivity;
     int unreadCount = 0;
     bool isGroup = false;
@@ -34,8 +35,9 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     void addConversation(const QString& id, const QString& displayName,
-                         const QDateTime& lastActivity, bool isGroup);
+                         const QString& description, const QDateTime& lastActivity, bool isGroup);
     void updateDisplayName(const QString& id, const QString& displayName);
+    void updateDescription(const QString& id, const QString& description);
     void updateLastActivity(const QString& id, const QDateTime& lastActivity);
     void incrementUnread(const QString& id);
     void clearUnread(const QString& id);
@@ -47,6 +49,9 @@ public:
 
     // Display name for a conversation id, or empty if unknown.
     Q_INVOKABLE QString displayNameFor(const QString& id) const;
+
+    // Group description for a conversation id, or empty if unknown or unset.
+    Q_INVOKABLE QString descriptionFor(const QString& id) const;
 
     // Whether a conversation is a group; false for a direct or unknown id.
     Q_INVOKABLE bool isGroupFor(const QString& id) const;

--- a/src/qml/ChatUi/ChatStore.qml
+++ b/src/qml/ChatUi/ChatStore.qml
@@ -22,6 +22,7 @@ QtObject {
     readonly property bool hasCurrentConversation: currentConversationId !== ""
     readonly property bool currentIsGroup: backend ? backend.currentIsGroup : false
     readonly property string currentDisplayName: backend ? backend.currentDisplayName : ""
+    readonly property string currentDescription: backend ? backend.currentDescription : ""
     readonly property string statusMessage: backend ? backend.statusMessage : qsTr("No backend")
     readonly property string myIdentity: backend ? backend.myIdentity : ""
 
@@ -61,9 +62,9 @@ QtObject {
         if (backend)
             backend.createConversation(address);
     }
-    function createGroup() {
+    function createGroup(name, description) {
         if (backend)
-            backend.createGroupConversation();
+            backend.createGroupConversation(name, description);
     }
     function requestMyAddress() {
         if (backend)

--- a/src/qml/ChatUi/MessageThreadPane.qml
+++ b/src/qml/ChatUi/MessageThreadPane.qml
@@ -16,6 +16,9 @@ Rectangle {
     required property var messageModel
     required property bool currentIsGroup
     required property string title
+    // Group description shown under the title; empty for direct conversations
+    // and unnamed groups.
+    property string description: ""
     required property string conversationId
     required property bool hasConversation
     required property bool online
@@ -41,6 +44,7 @@ Rectangle {
             Layout.fillWidth: true
             visible: root.hasConversation
             title: root.title
+            subtitle: root.description
         }
 
         ListView {

--- a/src/qml/ChatUi/NewGroupDialog.qml
+++ b/src/qml/ChatUi/NewGroupDialog.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Logos.Theme
+import Logos.Controls
+
+// Modal dialog that collects a name and an optional description for a new group
+// and emits them. Open it and connect groupDetailsEntered(); it clears its
+// inputs whenever it closes. Standalone: instantiate with no context, open(),
+// and read the signal.
+LogosDialog {
+    id: root
+
+    // Emitted with the trimmed name and description once the user confirms a
+    // non-empty name.
+    signal groupDetailsEntered(string name, string description)
+
+    title: qsTr("New Group")
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape
+    anchors.centerIn: Overlay.overlay
+    width: Math.min(480, (Overlay.overlay ? Overlay.overlay.width : 480) - 2 * Theme.spacing.large)
+
+    leftActions: [
+        LogosButton {
+            implicitWidth: 96
+            implicitHeight: 36
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
+    ]
+    rightActions: [
+        LogosButton {
+            implicitWidth: 96
+            implicitHeight: 36
+            //: Button that confirms creating the new group
+            text: qsTr("Create")
+            enabled: nameField.text.trim() !== ""
+            onClicked: root._accept()
+        }
+    ]
+
+    onOpened: nameField.forceActiveFocus()
+    onClosed: {
+        nameField.text = "";
+        descriptionField.clear();
+    }
+
+    contentItem: ColumnLayout {
+        spacing: Theme.spacing.medium
+
+        LogosText {
+            text: qsTr("Group name")
+            color: Theme.palette.textSecondary
+            font.pixelSize: Theme.typography.secondaryText
+            Layout.fillWidth: true
+        }
+
+        LogosTextField {
+            id: nameField
+            objectName: "groupNameField"
+            Layout.fillWidth: true
+            placeholderText: qsTr("e.g. Book Club")
+
+            // Enter confirms rather than moving focus: a valid group needs only
+            // the name, and the description is optional.
+            Connections {
+                target: nameField.textInput
+                function onAccepted() {
+                    root._accept();
+                }
+            }
+        }
+
+        LogosText {
+            text: qsTr("Description (optional)")
+            color: Theme.palette.textSecondary
+            font.pixelSize: Theme.typography.secondaryText
+            Layout.fillWidth: true
+        }
+
+        LogosScrollView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 80
+
+            LogosTextArea {
+                id: descriptionField
+                placeholderText: qsTr("What's this group about?")
+            }
+        }
+    }
+
+    // Emit the trimmed name and description and close. No-op on an empty name, so
+    // neither Enter nor Create can create a group without one.
+    function _accept() {
+        const name = nameField.text.trim();
+        if (name === "")
+            return;
+        root.groupDetailsEntered(name, descriptionField.text.trim());
+        root.close();
+    }
+}

--- a/src/qml/ChatUi/PaneHeader.qml
+++ b/src/qml/ChatUi/PaneHeader.qml
@@ -11,11 +11,14 @@ Rectangle {
     id: root
 
     property string title
+    // Optional secondary line under the title; empty hides it and the header
+    // keeps its title-only height.
+    property string subtitle
     // Trailing items (buttons, status dot) laid out right-aligned.
     default property alias trailing: trailingRow.data
 
     implicitWidth: 200
-    implicitHeight: 48
+    implicitHeight: Math.max(48, titleColumn.implicitHeight + 2 * Theme.spacing.small)
     color: Theme.palette.backgroundTertiary
 
     RowLayout {
@@ -24,14 +27,31 @@ Rectangle {
         anchors.rightMargin: Theme.spacing.medium
         spacing: Theme.spacing.small
 
-        LogosText {
-            text: root.title
-            textFormat: Text.PlainText
-            color: Theme.palette.text
-            font.pixelSize: Theme.typography.primaryText
-            font.weight: Theme.typography.weightBold
-            elide: Text.ElideRight
+        ColumnLayout {
+            id: titleColumn
+            spacing: 0
             Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+
+            LogosText {
+                text: root.title
+                textFormat: Text.PlainText
+                color: Theme.palette.text
+                font.pixelSize: Theme.typography.primaryText
+                font.weight: Theme.typography.weightBold
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
+
+            LogosText {
+                text: root.subtitle
+                visible: root.subtitle !== ""
+                textFormat: Text.PlainText
+                color: Theme.palette.textSecondary
+                font.pixelSize: Theme.typography.secondaryText
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
         }
 
         RowLayout {

--- a/src/qml/ChatUi/qmldir
+++ b/src/qml/ChatUi/qmldir
@@ -14,5 +14,6 @@ ConversationsPane 1.0 ConversationsPane.qml
 MessageThreadPane 1.0 MessageThreadPane.qml
 MembersPane 1.0 MembersPane.qml
 NewConversationDialog 1.0 NewConversationDialog.qml
+NewGroupDialog 1.0 NewGroupDialog.qml
 AddressDialog 1.0 AddressDialog.qml
 MemberAddInfoDialog 1.0 MemberAddInfoDialog.qml

--- a/src/qml/ChatView.qml
+++ b/src/qml/ChatView.qml
@@ -49,7 +49,7 @@ Item {
                     store.selectConversation(conversationId);
                 }
                 onNewConversationRequested: newConvDialog.open()
-                onNewGroupRequested: store.createGroup()
+                onNewGroupRequested: newGroupDialog.open()
                 onShowAddressRequested: store.requestMyAddress()
             }
 
@@ -60,6 +60,7 @@ Item {
                 messageModel: store.messageModel
                 currentIsGroup: store.currentIsGroup
                 title: store.currentDisplayName
+                description: store.currentDescription
                 conversationId: store.currentConversationId
                 hasConversation: store.hasCurrentConversation
                 online: store.online
@@ -100,6 +101,13 @@ Item {
         id: newConvDialog
         onAddressEntered: function (address) {
             store.createConversation(address);
+        }
+    }
+
+    NewGroupDialog {
+        id: newGroupDialog
+        onGroupDetailsEntered: function (name, description) {
+            store.createGroup(name, description);
         }
     }
 

--- a/tests/qml/tst_components.qml
+++ b/tests/qml/tst_components.qml
@@ -96,6 +96,13 @@ Item {
         }
     }
     Component {
+        id: paneHeaderSubtitleC
+        PaneHeader {
+            title: "Header"
+            subtitle: "A subtitle line"
+        }
+    }
+    Component {
         id: emptyStateC
         EmptyState {
             text: "Nothing here"
@@ -120,6 +127,10 @@ Item {
     Component {
         id: newConvDialogC
         NewConversationDialog {}
+    }
+    Component {
+        id: newGroupDialogC
+        NewGroupDialog {}
     }
     Component {
         id: addressDialogC
@@ -172,6 +183,10 @@ Item {
         id: confirmedSpy
         signalName: "confirmed"
     }
+    SignalSpy {
+        id: groupDetailsSpy
+        signalName: "groupDetailsEntered"
+    }
 
     TestCase {
         name: "ChatUiComponents"
@@ -207,8 +222,19 @@ Item {
 
         function test_dialogsInstantiate() {
             instantiate(newConvDialogC);
+            instantiate(newGroupDialogC);
             instantiate(addressDialogC);
             instantiate(memberAddInfoDialogC);
+        }
+
+        // A title-only header keeps its 48px height, so panes that set no
+        // subtitle are unchanged; a subtitled header instantiates and is no
+        // shorter.
+        function test_paneHeaderSubtitle() {
+            const plain = instantiate(paneHeaderC);
+            compare(plain.implicitHeight, 48, "a title-only header stays 48px");
+            const withSubtitle = instantiate(paneHeaderSubtitleC);
+            verify(withSubtitle.implicitHeight >= 48, "a subtitled header is at least as tall");
         }
 
         function test_delegatesInstantiate() {
@@ -254,6 +280,35 @@ Item {
             dlg._accept();
             compare(addressSpy.count, 0, "an empty address must not be accepted");
             dlg.close();
+        }
+
+        // The group dialog gates on a non-blank name: an empty name is a no-op,
+        // a filled name emits once with the trimmed name, and an unentered
+        // description comes through empty.
+        function test_newGroupDialogValidation() {
+            const dlg = createTemporaryObject(newGroupDialogC, this);
+            verify(dlg);
+            groupDetailsSpy.target = dlg;
+            groupDetailsSpy.clear();
+            dlg.open();
+
+            dlg._accept();
+            compare(groupDetailsSpy.count, 0, "an empty name must not be accepted");
+
+            let nameField = null;
+            const kids = dlg.contentItem.children;
+            for (let i = 0; i < kids.length; ++i) {
+                if (kids[i].objectName === "groupNameField") {
+                    nameField = kids[i];
+                    break;
+                }
+            }
+            verify(nameField, "the group name field must be reachable");
+            nameField.text = "  Book Club  ";
+            dlg._accept();
+            compare(groupDetailsSpy.count, 1, "a non-blank name must be accepted once");
+            compare(groupDetailsSpy.signalArguments[0][0], "Book Club", "the name must be trimmed");
+            compare(groupDetailsSpy.signalArguments[0][1], "", "an unentered description is empty");
         }
 
         // Confirming the explainer emits confirmed() so the caller can proceed


### PR DESCRIPTION
Creating a group opened an unnamed conversation labelled "Group <short-id>". A new dialog now collects a required group name and an optional description: the shared name becomes every member's display name for the conversation, and the description shows under the title in the message thread header. Metadata is set once at creation, so a joiner reads the same name and description the creator set.

Display name precedence is the local nickname, then the group's shared name, then the "Group <short-id>" fallback. The chat_module pin moves to the commit that adds the name and description to create_group_conversation, the Conversation record, and the conversation_created event; the backend threads them through the conversation model and exposes the current conversation's description as a property the thread header binds.


---

Note (not part of the commit): the chat_module pin is on the unmerged head of logos-co/logos-chat-module#48, which itself pins the unmerged head of logos-messaging/libchat#183. Re-pin down the chain to each squash-merge commit once those land, folding each re-pin into this pin commit, and drop this note.
