### PR TITLE
feat: make message text selectable and copyable

### DIFF
--- a/src/qml/ChatUi/ChatTheme.qml
+++ b/src/qml/ChatUi/ChatTheme.qml
@@ -23,4 +23,12 @@ QtObject {
     readonly property color bubblePeerText: Theme.palette.text
     readonly property color bubbleOwn: Theme.palette.primary
     readonly property color bubbleOwnText: "#000000"
+
+    // Selection highlight for message text, inverted per side so the marked run
+    // stays legible on either bubble background.
+    // TODO(upstream: logos-design-system): selection roles.
+    readonly property color bubblePeerSelection: Theme.palette.primary
+    readonly property color bubblePeerSelectedText: "#000000"
+    readonly property color bubbleOwnSelection: "#000000"
+    readonly property color bubbleOwnSelectedText: Theme.palette.primary
 }

--- a/src/qml/ChatUi/MessageBubble.qml
+++ b/src/qml/ChatUi/MessageBubble.qml
@@ -60,6 +60,7 @@ Item {
 
     Rectangle {
         id: bubble
+        objectName: "bubble"
         y: root.showSender ? senderLabel.y + senderLabel.height + Theme.spacing.tiny : daySeparator.height
         anchors.left: root.isMe ? undefined : parent.left
         anchors.right: root.isMe ? parent.right : undefined
@@ -83,14 +84,15 @@ Item {
             anchors.bottomMargin: Theme.spacing.small
             spacing: Theme.spacing.tiny
 
-            LogosText {
+            SelectableText {
                 id: contentText
+                objectName: "messageText"
                 width: parent.width
                 text: root.content
-                textFormat: Text.PlainText
                 color: root.isMe ? ChatTheme.bubbleOwnText : ChatTheme.bubblePeerText
+                selectionColor: root.isMe ? ChatTheme.bubbleOwnSelection : ChatTheme.bubblePeerSelection
+                selectedTextColor: root.isMe ? ChatTheme.bubbleOwnSelectedText : ChatTheme.bubblePeerSelectedText
                 font.pixelSize: Theme.typography.primaryText
-                wrapMode: Text.Wrap
             }
 
             LogosText {

--- a/src/qml/ChatUi/SelectableText.qml
+++ b/src/qml/ChatUi/SelectableText.qml
@@ -1,0 +1,20 @@
+import QtQuick
+
+import Logos.Theme
+
+// Read-only, mouse-selectable text carrying LogosText's typography defaults. A
+// bare TextEdit rather than LogosTextArea, whose background and paddings read as
+// an input field. Standalone.
+// TODO(upstream: logos-design-system): a selectable text label.
+TextEdit {
+    id: root
+
+    readOnly: true
+    selectByMouse: true
+    textFormat: TextEdit.PlainText
+    wrapMode: TextEdit.Wrap
+    font.family: Theme.typography.publicSans
+    font.pixelSize: Theme.typography.primaryText
+    font.weight: Theme.typography.weightRegular
+    color: Theme.palette.text
+}

--- a/src/qml/ChatUi/qmldir
+++ b/src/qml/ChatUi/qmldir
@@ -3,6 +3,7 @@ singleton ChatTheme 1.0 ChatTheme.qml
 ChatStore 1.0 ChatStore.qml
 PaneHeader 1.0 PaneHeader.qml
 EmptyState 1.0 EmptyState.qml
+SelectableText 1.0 SelectableText.qml
 ClipboardProxy 1.0 ClipboardProxy.qml
 StatusBar 1.0 StatusBar.qml
 MessageComposer 1.0 MessageComposer.qml

--- a/tests/qml/tst_components.qml
+++ b/tests/qml/tst_components.qml
@@ -334,6 +334,39 @@ Item {
             verify(!bubble.showSender, "own messages never show a sender label");
         }
 
+        // The body is read-only selectable text, and a selection yields the raw
+        // string, so markup in a message stays literal.
+        function test_messageBubbleTextSelectable() {
+            const bubble = instantiate(messageBubbleC);
+            const body = findField(bubble, "messageText");
+            verify(body, "the message text must be reachable");
+            verify(body.readOnly, "the body must not be editable");
+            verify(body.selectByMouse, "the body must be selectable with the mouse");
+
+            body.selectAll();
+            compare(body.selectedText, "<b>not bold</b>", "the selection is the literal plain text");
+        }
+
+        // The bubble hugs a short message and caps a long one at 70% of the row.
+        // Guards the sizing formula, which reads the body's implicit size.
+        function test_messageBubbleSizing() {
+            const shortBubble = createTemporaryObject(messageBubbleC, testRoot);
+            const longBubble = createTemporaryObject(messageBubbleC, testRoot);
+            verify(shortBubble && longBubble, "both bubbles must instantiate");
+            shortBubble.width = 400;
+            shortBubble.content = "Hi";
+            longBubble.width = 400;
+            longBubble.content = "A message long enough to need wrapping. ".repeat(10);
+
+            const shortBox = findField(shortBubble, "bubble");
+            const longBox = findField(longBubble, "bubble");
+            verify(shortBox && longBox, "both bubble backgrounds must be reachable");
+            verify(shortBox.width > 0, "a short bubble must still have a width");
+            verify(shortBox.width < longBox.width, "a short message makes a narrower bubble");
+            compare(longBox.width, 280, "a long message caps at 70% of the row");
+            verify(longBox.height > shortBox.height, "wrapped content makes a taller bubble");
+        }
+
         // The current conversation highlights; a different one does not.
         function test_conversationDelegateHighlight() {
             const del = instantiate(conversationDelegateC);


### PR DESCRIPTION
Closes #21 

Getting a message body out of the app meant retyping it: the bubble rendered its content as a plain Text, which has no selection support.

Selecting text moves focus off the composer, so Enter stops sending until the user clicks back into it. That is inherent to the selected item being the one that receives Ctrl+C, and is accepted rather than papered over with focus-restoring machinery that would fight the user mid-selection.

