### PR TITLE
feat: stop choosing the delivery node's port

### DIFF
--- a/.github/workflows/group-chat.yml
+++ b/.github/workflows/group-chat.yml
@@ -8,8 +8,8 @@ name: Group chat
 # screenshots as an artifact for review.
 #
 # This job is Linux only: it launches three standalone app instances on one host,
-# which the script keeps apart via distinct data dirs, delivery ports, and
-# inspector ports. macOS still exercises the group flow through the chat-ui-group
+# which the script keeps apart via distinct data dirs and inspector ports. macOS
+# still exercises the group flow through the chat-ui-group
 # spec in doctests.yml; this job is the dedicated, race-free gate for it (it runs
 # the flow against the checked-out tree rather than a freshly pushed github ref).
 

--- a/.github/workflows/two-instance-exchange.yml
+++ b/.github/workflows/two-instance-exchange.yml
@@ -9,8 +9,8 @@ name: Two-instance exchange
 # the UI changes.
 #
 # This job is Linux only: it launches two standalone app instances on one host,
-# which the script keeps apart via distinct data dirs, delivery ports, and
-# inspector ports. macOS still exercises the round-trip through the exchange spec
+# which the script keeps apart via distinct data dirs and inspector ports. macOS
+# still exercises the round-trip through the exchange spec
 # in doctests.yml; this job is the dedicated, robust gate for it.
 
 on:

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ The standalone app starts Logos Core, loads `capability_module` and `chat_module
 ### Running multiple instances on one machine
 
 To try a real conversation or group locally, run two or more standalone apps
-side by side on the same host. Each instance needs its own session directory
-and its own delivery-node port; the UI-to-backend QtRO socket name is randomized
-per instance, so nothing else has to be set:
+side by side on the same host. Each instance needs its own session directory;
+the UI-to-backend QtRO socket name is randomized per instance and the delivery
+node listens on ports it picks itself, so nothing else has to be set:
 
 ```bash
 # window A
-CHAT_MODULE_DELIVERY_PORT=60000 nix run . -- --user-dir ~/.local/share/chat_a
+nix run . -- --user-dir ~/.local/share/chat_a
 # window B
-CHAT_MODULE_DELIVERY_PORT=60001 nix run . -- --user-dir ~/.local/share/chat_b
+nix run . -- --user-dir ~/.local/share/chat_b
 ```
 
-Add further windows the same way, giving each a fresh session directory and
-delivery port (`chat_c` / `60002`, and so on).
+Add further windows the same way, giving each a fresh session directory
+(`chat_c`, and so on).
 
 The standalone app hands every module its own directory under
 `<session dir>/module_data`, so `--user-dir` is what keeps two instances' chat
@@ -74,7 +74,6 @@ state apart; it defaults to the platform application data location.
 | Variable | Purpose |
 |---|---|
 | `LOGOS_USER_DIR` | The standalone app's session directory, for when setting it by environment is easier than by flag. `--user-dir` wins over it. |
-| `CHAT_MODULE_DELIVERY_PORT` | The local delivery (Waku) node's port, bound by the node, so it must be distinct per instance. Defaults to a compiled-in port. |
 | `QML_INSPECTOR_PORT` | Only needed when attaching the [logos-qt-mcp](https://github.com/logos-co/logos-qt-mcp) inspector to drive an instance programmatically (default 3768); give each a distinct one then. Interactive use does not need it. |
 
 Each node joins the `logos.test` Waku fleet and publishes its key package during

--- a/docs/two-instance-exchange.md
+++ b/docs/two-instance-exchange.md
@@ -18,21 +18,20 @@ inspector protocol to **both** instances at once, so it can read Alice's address
 out of her window and hand it to Bob, then capture each side of the
 conversation. The screenshots below are produced by that script.
 
-Two instances coexist on one host because each picks a random QtRO socket name;
-the script gives each its own session dir (`--user-dir`), delivery node port
-(`CHAT_MODULE_DELIVERY_PORT`), and QML inspector port (`QML_INSPECTOR_PORT`).
+Two instances coexist on one host because each picks a random QtRO socket name
+and each delivery node picks its own listening ports; the script gives each its
+own session dir (`--user-dir`) and QML inspector port (`QML_INSPECTOR_PORT`).
 
 ## Run two instances interactively
 
-To exchange a message by hand, launch two standalone apps; the delivery ports
-must differ (each is bound by its node), and a distinct session dir keeps the
-two module instances cleanly apart:
+To exchange a message by hand, launch two standalone apps; a distinct session
+dir keeps the two module instances cleanly apart:
 
 ```bash
 # window A
-CHAT_MODULE_DELIVERY_PORT=60000 nix run . -- --user-dir ~/.local/share/chat_a
+nix run . -- --user-dir ~/.local/share/chat_a
 # window B
-CHAT_MODULE_DELIVERY_PORT=60001 nix run . -- --user-dir ~/.local/share/chat_b
+nix run . -- --user-dir ~/.local/share/chat_b
 ```
 
 Both nodes join the `logos.test` Waku fleet (and publish their key packages to

--- a/doctests/exchange/run-exchange-show.sh
+++ b/doctests/exchange/run-exchange-show.sh
@@ -50,7 +50,7 @@ trap show_cleanup EXIT
 # closed until the finished window is ready. KEEP_INSTANCES leaves Alice and Bob
 # running with the completed thread on screen.
 echo "=== phase 1: two-party exchange (instances kept alive) ==="
-ALICE_PORT="$ALICE_PORT" BOB_PORT=4769 ALICE_DELIVERY=60010 BOB_DELIVERY=60011 \
+ALICE_PORT="$ALICE_PORT" BOB_PORT=4769 \
   WORK_DIR="$DATA_DIR" KEEP_WORK_DIR=1 KEEP_INSTANCES=1 OUT_DIR="$OUT_DIR" \
   bash "$here/run-exchange.sh" "$OUT_DIR"
 

--- a/doctests/exchange/run-exchange.sh
+++ b/doctests/exchange/run-exchange.sh
@@ -2,13 +2,13 @@
 # Role: headless two-party exchange test driver (CI); see run-exchange-show.sh for the doc-test display variant.
 # Regenerate the two-instance message-exchange screenshots for the docs.
 #
-# Launches two logos-chat-ui instances offscreen — each with its own data dir,
-# delivery-node port, and QML inspector port — drives a real bidirectional
-# message exchange between them via the logos-qt-mcp inspector protocol
-# (run-exchange.mjs), and writes the screenshots to OUT_DIR. Exits non-zero if
-# the exchange does not complete, so this doubles as an end-to-end integration
-# check. Two instances coexist because each picks a random QtRO socket name and
-# we give each a distinct data dir / delivery port / inspector port.
+# Launches two logos-chat-ui instances offscreen — each with its own data dir
+# and QML inspector port — drives a real bidirectional message exchange between
+# them via the logos-qt-mcp inspector protocol (run-exchange.mjs), and writes the
+# screenshots to OUT_DIR. Exits non-zero if the exchange does not complete, so
+# this doubles as an end-to-end integration check. Two instances coexist because
+# each picks a random QtRO socket name and its own delivery ports, and we give
+# each a distinct data dir / inspector port.
 #
 # Usage:
 #   doctests/exchange/run-exchange.sh [out-dir]
@@ -30,8 +30,6 @@ OUT_DIR="${OUT_DIR:-${1:-$repo_root/docs/images/exchange}}"
 FLAKE="${FLAKE:-$repo_root}"
 ALICE_PORT="${ALICE_PORT:-3768}"
 BOB_PORT="${BOB_PORT:-3769}"
-ALICE_DELIVERY="${ALICE_DELIVERY:-60010}"
-BOB_DELIVERY="${BOB_DELIVERY:-60011}"
 WORK_DIR="${WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/chat-exchange.XXXXXX")}"
 mkdir -p "$OUT_DIR" "$WORK_DIR"
 
@@ -88,14 +86,13 @@ cleanup() {
 trap cleanup EXIT
 
 launch() {
-  local name="$1" inspector="$2" delivery="$3"
+  local name="$1" inspector="$2"
   mkdir -p "$WORK_DIR/$name"
   QT_QPA_PLATFORM=offscreen QT_FORCE_STDERR_LOGGING=1 \
     QML_INSPECTOR_PORT="$inspector" \
-    CHAT_MODULE_DELIVERY_PORT="$delivery" \
     setsid "$APP_BIN" -platform offscreen --user-dir "$WORK_DIR/$name" \
       > "$WORK_DIR/$name.log" 2>&1 &
-  echo "launched $name (inspector $inspector, delivery $delivery)"
+  echo "launched $name (inspector $inspector)"
 }
 
 wait_for_port() {
@@ -109,8 +106,8 @@ wait_for_port() {
   return 1
 }
 
-launch alice "$ALICE_PORT" "$ALICE_DELIVERY"
-launch bob   "$BOB_PORT"   "$BOB_DELIVERY"
+launch alice "$ALICE_PORT"
+launch bob   "$BOB_PORT"
 wait_for_port "$ALICE_PORT"
 wait_for_port "$BOB_PORT"
 

--- a/doctests/group/run-group-show.sh
+++ b/doctests/group/run-group-show.sh
@@ -28,9 +28,9 @@ OUT_DIR="${OUT_DIR:-$BASE/images}"
 SHOW_PORT="${SHOW_PORT:-3768}"
 # Carol (the last member to join) is the window we expose: her screen shows the
 # creator's message received with a sender label beside the full roster.
-# The flow runs on 4778-4780 / delivery 60020-60022 — distinct from the #exchange
-# app's 4768-4769 / 60010-60011, so the two don't collide when the doc-test runs
-# both specs in one job and a prior app's setsid'd module hosts outlive teardown.
+# The flow runs on inspector ports 4778-4780 — distinct from the #exchange app's
+# 4768-4769, so the two don't collide when the doc-test runs both specs in one
+# job and a prior app's setsid'd module hosts outlive teardown.
 CAROL_PORT=4780
 mkdir -p "$DATA_DIR" "$OUT_DIR"
 
@@ -56,7 +56,6 @@ trap show_cleanup EXIT
 # three running with the completed group on screen.
 echo "=== phase 1: three-party group chat (instances kept alive) ==="
 ALICE_PORT=4778 BOB_PORT=4779 CAROL_PORT="$CAROL_PORT" \
-  ALICE_DELIVERY=60020 BOB_DELIVERY=60021 CAROL_DELIVERY=60022 \
   WORK_DIR="$DATA_DIR" KEEP_WORK_DIR=1 KEEP_INSTANCES=1 OUT_DIR="$OUT_DIR" \
   bash "$here/run-group.sh" "$OUT_DIR"
 

--- a/doctests/group/run-group.sh
+++ b/doctests/group/run-group.sh
@@ -2,15 +2,14 @@
 # Role: headless three-party group-chat test driver (CI); see run-group-show.sh for the doc-test display variant.
 # Regenerate the three-instance group-chat screenshots for the docs.
 #
-# Launches three logos-chat-ui instances offscreen — each with its own data dir,
-# delivery-node port, and QML inspector port — drives a real group conversation
-# between them via the logos-qt-mcp inspector protocol (run-group.mjs): Alice
-# creates the group, invites Bob and Carol, and once the roster converges sends a
-# message that fans out to both. Writes the screenshots to OUT_DIR and exits
-# non-zero if the flow does not complete, so this doubles as an end-to-end
-# integration check. The three instances coexist because each picks a random
-# QtRO socket name and we give each a distinct data dir / delivery port /
-# inspector port.
+# Launches three logos-chat-ui instances offscreen — each with its own data dir
+# and QML inspector port — drives a real group conversation between them via the
+# logos-qt-mcp inspector protocol (run-group.mjs): Alice creates the group,
+# invites Bob and Carol, and once the roster converges sends a message that fans
+# out to both. Writes the screenshots to OUT_DIR and exits non-zero if the flow
+# does not complete, so this doubles as an end-to-end integration check. The three
+# instances coexist because each picks a random QtRO socket name and its own
+# delivery ports, and we give each a distinct data dir / inspector port.
 #
 # Usage:
 #   doctests/group/run-group.sh [out-dir]
@@ -33,9 +32,6 @@ FLAKE="${FLAKE:-$repo_root}"
 ALICE_PORT="${ALICE_PORT:-3768}"
 BOB_PORT="${BOB_PORT:-3769}"
 CAROL_PORT="${CAROL_PORT:-3770}"
-ALICE_DELIVERY="${ALICE_DELIVERY:-60010}"
-BOB_DELIVERY="${BOB_DELIVERY:-60011}"
-CAROL_DELIVERY="${CAROL_DELIVERY:-60012}"
 WORK_DIR="${WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/chat-group.XXXXXX")}"
 mkdir -p "$OUT_DIR" "$WORK_DIR"
 
@@ -76,14 +72,13 @@ cleanup() {
 trap cleanup EXIT
 
 launch() {
-  local name="$1" inspector="$2" delivery="$3"
+  local name="$1" inspector="$2"
   mkdir -p "$WORK_DIR/$name"
   QT_QPA_PLATFORM=offscreen QT_FORCE_STDERR_LOGGING=1 \
     QML_INSPECTOR_PORT="$inspector" \
-    CHAT_MODULE_DELIVERY_PORT="$delivery" \
     setsid "$APP_BIN" -platform offscreen --user-dir "$WORK_DIR/$name" \
       > "$WORK_DIR/$name.log" 2>&1 &
-  echo "launched $name (inspector $inspector, delivery $delivery)"
+  echo "launched $name (inspector $inspector)"
 }
 
 # Surface each instance's boot/runtime output — the apps launch headless, so
@@ -110,9 +105,9 @@ wait_for_port() {
   return 1
 }
 
-launch alice "$ALICE_PORT" "$ALICE_DELIVERY"
-launch bob   "$BOB_PORT"   "$BOB_DELIVERY"
-launch carol "$CAROL_PORT" "$CAROL_DELIVERY"
+launch alice "$ALICE_PORT"
+launch bob   "$BOB_PORT"
+launch carol "$CAROL_PORT"
 wait_for_port "$ALICE_PORT"
 wait_for_port "$BOB_PORT"
 wait_for_port "$CAROL_PORT"

--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1784705511,
-        "narHash": "sha256-hIrm9YwvytlpEssVgPzGr6CA8m4pUV9WL3/5QYJZXvM=",
+        "lastModified": 1784708483,
+        "narHash": "sha256-FyEMfg/wmm5Yj83edrfDrcE63IkVP6rxJybBJ0GN65M=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "26d593988041fc13245be40787efac85971511fc",
+        "rev": "8255d9d80b6162fef66ca89ab97e5880a6140604",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "26d593988041fc13245be40787efac85971511fc",
+        "rev": "8255d9d80b6162fef66ca89ab97e5880a6140604",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,9 @@
     # Follow chat_module's own builder, so the logos-protocol/logos-qt-sdk
     # chain matches across both.
     logos-module-builder.follows = "chat_module/logos-module-builder";
-    # Pinned to the merged chat_module rev whose init contract reads the
-    # host-assigned instance path; release tags predate it.
-    chat_module.url = "github:logos-co/logos-chat-module/26d593988041fc13245be40787efac85971511fc";
+    # Pinned to the chat_module rev whose init contract drops the delivery port;
+    # release tags predate it.
+    chat_module.url = "github:logos-co/logos-chat-module/8255d9d80b6162fef66ca89ab97e5880a6140604";
     # Follow chat_module's delivery pin, so both build against the same
     # delivery module.
     logos-delivery-module.follows = "chat_module/logos-delivery-module";

--- a/src/ChatBackend.cpp
+++ b/src/ChatBackend.cpp
@@ -9,19 +9,15 @@
 
 #include <QCoreApplication>
 #include <QDateTime>
-#include <QDebug>
 #include <QVariantMap>
-#include <cstdlib>
 #include <utility>
 
 namespace {
 
-constexpr int kDefaultDeliveryPort = 60000;
 // Preview cap; mirrors chat_module's own 160-char truncation so a live preview
 // matches the one a rehydrate reads back from the module.
 constexpr int kPreviewMaxChars = 160;
 constexpr const char* kDefaultDeliveryPreset = "logos.test";
-constexpr const char* kDeliveryPortEnvVar = "CHAT_MODULE_DELIVERY_PORT";
 
 QDateTime msToDateTime(qint64 ms)
 {
@@ -92,33 +88,14 @@ MemberListModel* ChatBackend::memberModel() const
     return m_memberModel;
 }
 
-// ── delivery port ───────────────────────────────────────────────────────────
-
-int ChatBackend::resolveDeliveryPort()
-{
-    const char* env = std::getenv(kDeliveryPortEnvVar);
-    if (!env || !*env) return kDefaultDeliveryPort;
-
-    bool ok = false;
-    const int parsed = QString::fromUtf8(env).toInt(&ok);
-    if (!ok) {
-        qWarning() << "ChatBackend: ignoring non-integer" << kDeliveryPortEnvVar << "=" << env;
-        return kDefaultDeliveryPort;
-    }
-    return parsed;
-}
-
 // ── lifecycle ───────────────────────────────────────────────────────────────
 
 void ChatBackend::initialiseModule()
 {
     setChatStatus(ChatBackendSimpleSource::Initialising);
     setStatusMessage(QStringLiteral("Initialising chat..."));
-    const int port = resolveDeliveryPort();
-    qDebug() << "ChatBackend: init, delivery port" << port;
 
-    const LogosResult res = modules().chat_module.init(QString::fromLatin1(kDefaultDeliveryPreset),
-                                                       port);
+    const LogosResult res = modules().chat_module.init(QString::fromLatin1(kDefaultDeliveryPreset));
     if (!res.success) {
         const QString reason = res.getError<QString>();
         setChatStatus(ChatBackendSimpleSource::Error);

--- a/src/ChatBackend.h
+++ b/src/ChatBackend.h
@@ -48,10 +48,6 @@ public slots:
     void refreshMembers() override;
 
 private:
-    // Honours $CHAT_MODULE_DELIVERY_PORT, otherwise the compiled-in default.
-    // Lets multiple instances coexist on one host.
-    static int resolveDeliveryPort();
-
     void initialiseModule();
     void subscribeToEvents();
     void rehydrateConversations();


### PR DESCRIPTION
Running several instances on one host meant inventing a distinct delivery port for each and threading it through an environment variable, the docs, and both doc-test drivers, a coordination burden that bought nothing the transport cannot decide for itself.

chat_module's init no longer takes a port and its delivery node listens on ports it picks itself, so a session directory is the only thing that has to differ per instance.


---

The `chat_module` flake pin is a branch rev, for logos-chat-module#53; it moves to the merged commit before this lands.
