### PR TITLE
ci: cache Nix builds in Attic

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -30,9 +30,15 @@ concurrency:
   group: doctests-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   doctests:
     name: doc-tests (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
+    env:
+      ATTIC_CONFIGURED: ${{ secrets.ATTIC_ENDPOINT != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,12 +53,33 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
           name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Skipped
+      # until this repo is granted Attic credentials, and on fork PRs, which get
+      # no secrets: an empty endpoint fails `attic use`.
+      - name: Setup Attic cache
+        if: env.ATTIC_CONFIGURED == 'true'
+        uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       # Resolve the commit under test. For pull requests this is the PR's head
       # commit (not the synthetic merge commit); for pushes it's the pushed

--- a/.github/workflows/group-chat.yml
+++ b/.github/workflows/group-chat.yml
@@ -23,9 +23,15 @@ concurrency:
   group: group-chat-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   group:
     name: group chat (ubuntu-latest)
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
+    env:
+      ATTIC_CONFIGURED: ${{ secrets.ATTIC_ENDPOINT != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -35,12 +41,33 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
           name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Skipped
+      # until this repo is granted Attic credentials, and on fork PRs, which get
+      # no secrets: an empty endpoint fails `attic use`.
+      - name: Setup Attic cache
+        if: env.ATTIC_CONFIGURED == 'true'
+        uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       # The flow runs against the commit under test (FLAKE defaults to the
       # checked-out tree) and needs a real network: the three delivery nodes find

--- a/.github/workflows/qml-checks.yml
+++ b/.github/workflows/qml-checks.yml
@@ -23,9 +23,15 @@ concurrency:
   group: qml-checks-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   qml-checks:
     name: qmllint + Qt Quick Test
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
+    env:
+      ATTIC_CONFIGURED: ${{ secrets.ATTIC_ENDPOINT != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -35,12 +41,33 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
           name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Skipped
+      # until this repo is granted Attic credentials, and on fork PRs, which get
+      # no secrets: an empty endpoint fails `attic use`.
+      - name: Setup Attic cache
+        if: env.ATTIC_CONFIGURED == 'true'
+        uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       # Build the standalone app to obtain the design system the plugin QML
       # imports. The app exposes no buildable package attr, so recover its

--- a/.github/workflows/two-instance-exchange.yml
+++ b/.github/workflows/two-instance-exchange.yml
@@ -23,9 +23,15 @@ concurrency:
   group: two-instance-exchange-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   exchange:
     name: two-instance exchange (ubuntu-latest)
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
+    env:
+      ATTIC_CONFIGURED: ${{ secrets.ATTIC_ENDPOINT != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -35,12 +41,33 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
           name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Skipped
+      # until this repo is granted Attic credentials, and on fork PRs, which get
+      # no secrets: an empty endpoint fails `attic use`.
+      - name: Setup Attic cache
+        if: env.ATTIC_CONFIGURED == 'true'
+        uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       # The exchange runs against the commit under test (FLAKE defaults to the
       # checked-out tree) and needs a real network: the two delivery nodes find


### PR DESCRIPTION
Nothing here populates a binary cache. The Cachix step has never had a token, so all four workflows rebuild the same app closure from source on every push, four times over, and the doc-test job spends more than twenty minutes on it before the first spec runs.

Push to the Logos Attic cache from every build: master jobs enter the public-cache environment and push to the public cache, everything else uses the repo-wide token and the ci cache. That step self-skips until this repo is granted Attic credentials, and on fork PRs, which receive no secrets; `attic use` fails on an empty endpoint.

Both caches serve reads anonymously, so the substituter goes in the Nix install rather than behind those credentials. Cachix stays on as a read-only substituter, since Attic does not yet carry the Rust crate closure.

---

Inert until infra provisions this repo: it is absent from the infra-ci Attic allowlist (`ansible/group_vars/attic.yml`), so it has no `ATTIC_ENDPOINT` / `ATTIC_TOKEN_CI` and no `public-cache` environment. Until then the push step self-skips and every job stays green on Cachix alone; it starts publishing with no further edits once the secrets exist.

One open question worth re-checking after that: the read-only substituter produced no measurable gain across two before/after `qml-checks` runs (identical 68 derivations built, nothing fetched from Attic), even though `nix config show` lists both caches, the paths are present and correctly signed, and `nix-store --realise` pulls them on a runner with no credentials.
