### PR TITLE
feat: add the lucide messages-square icon as the module icon

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,7 @@
   "description": "Chat App for Logos - Private messaging interface",
   "main": "chat_ui_plugin",
   "view": "qml/ChatView.qml",
+  "icon": "src/icons/messages-square.svg",
   "dependencies": ["chat_module", "delivery_module"],
   "codegen": {
     "rep": "src/ChatBackend.rep",

--- a/src/icons/messages-square.svg
+++ b/src/icons/messages-square.svg
@@ -1,0 +1,18 @@
+<!-- Lucide "messages-square" icon (https://lucide.dev/icons/messages-square),
+     ISC License, Copyright (c) Lucide Icons and Contributors.
+     stroke changed from currentColor to #FFFFFF: Qt SVG resolves
+     currentColor to black, which is invisible on the dark theme. -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 10a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 14.286V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+  <path d="M20 9a2 2 0 0 1 2 2v10.286a.71.71 0 0 1-1.212.502l-2.202-2.202A2 2 0 0 0 17.172 19H10a2 2 0 0 1-2-2v-1" />
+</svg>


### PR DESCRIPTION
Adds an `icon` slot to `metadata.json` pointing to the [Lucide `messages-square` icon](https://lucide.dev/icons/messages-square) (ISC), added as `src/icons/messages-square.svg`. Basecamp shows it on the app tile, sidebar entry, and window icon.

The stroke is changed from `currentColor` to `#FFFFFF`: Qt SVG resolves `currentColor` to black, invisible on the dark theme.

Verified `nix build` and `nix build .#lgx` both bundle the icon next to the module's `metadata.json`.

Same change as logos-co/logos-delivery-demo#14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)