### PR TITLE
fix(windows): drop the unused krb5 runtime dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,7 @@
   "nix": {
     "packages": {
       "build": [],
-      "runtime": ["qt6.qtdeclarative", "zstd", "krb5", "abseil-cpp"]
+      "runtime": ["qt6.qtdeclarative", "zstd", "abseil-cpp"]
     },
     "external_libraries": [],
     "cmake": { "find_packages": [], "extra_sources": [] }


### PR DESCRIPTION
`chat_ui` declared `krb5` among its runtime nix packages. Nothing in the module uses it — there is no kerberos or gssapi reference anywhere in the sources. The line arrived with the qml+c++ backend migration, copied from the example list in logos-module-builder's own `docs/configuration.md`.

It is not inert, though. `krb5` pulls in a transitive `bash`, whose `meta.platforms` excludes mingw, so an `x86_64-windows` evaluation refuses before it ever reaches a compiler:

```
error: Refusing to evaluate package 'bash-5.3p9' in .../pkgs/shells/bash/5.nix:266
because it is not available on the requested hostPlatform:
  hostPlatform.system = "x86_64-windows"
```

This is a case of `meta.platforms` being unreliable as a proxy: krb5 itself claims Windows support, and the refusal comes from a package two hops down.

## Verification

An A/B against **current master**, with input overrides only where Windows needs them, so the only variable is this line:

| | `x86_64-linux` build | `x86_64-windows` eval |
|---|---|---|
| with `krb5` (baseline) | ✅ green | ❌ refuses on transitive `bash` |
| without `krb5` (this PR) | ✅ green | ✅ drv resolves |

The removal is a no-op natively and unblocks evaluation for Windows.

## Note on the first CI run

The initial push of this branch was cut from a commit that was a clean ancestor of `master` but ten commits behind it — so the diff was correct, but the doc-test built and drove a chat UI predating #48 (the cards/avatars rebuild), #42 (the "DM" rename) and #54 (the chat_module 0.2.2 bump). That is why `Drive the app` failed with `click_object: element not found` while every other job passed. The branch has been rebased onto current `master`; the failure was an artefact of the stale base, not of this change.

## Scope

This clears `chat_ui`'s own Windows *evaluation* blocker. It does not make `chat_ui` build for Windows end to end yet. With this line removed the cross build now gets all the way to chat_ui's own plugin objects (24/26) and stops at:

```
generated_code/include/logos_sdk.h:5:10: fatal error: chat_module_api.h: No such file or directory
```

Worth being precise about that one, since it is easy to misread as a dependency failure: `chat_module` v0.2.2 **does** cross successfully, and its Windows headers output does contain `chat_module_api.h`. The gap is that a dependency's generated API header is not placed on the include path for the cross target. Separate issue, tracked on its own.

## Note

The same copied line — `"runtime": ["qt6.qtdeclarative", "zstd", "krb5", "abseil-cpp"]` — is present verbatim in seven other modules (counter, logos-accounts-ui, logos-blockchain-ui, logos-execution-zone-wallet-ui, logos-storage-ui, logos-wallet-ui, wallet-ui). Worth fixing the docs example so new modules stop inheriting it; tracked separately rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)